### PR TITLE
Update Gemfile for a later version of eventmachine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # for running the server
-gem "eventmachine", "1.0.0.rc.4"
+gem "eventmachine", "~>1.0.0"
 gem 'thin'
 gem 'rack'


### PR DESCRIPTION
Fixes problems encountered related to old version of eventmachine when running `bundle exec rake server` (https://github.com/eventmachine/eventmachine/issues/389)

(rubyeventmachine.so: undefined symbol: rb_enable_interrupt)

NB: you probably don't want to merge this patch directly, as you will want to update the Gemfile.lock simultaneously by running `bundle update` locally. Feel free to use this fix to assist in fixing this issue.
