### PR TITLE
Change absolute paths to relative ones.

### DIFF
--- a/templates/about-dialog.html
+++ b/templates/about-dialog.html
@@ -3,13 +3,13 @@
     <div class="modal-content">
       <div class="modal-body">
       	<div class="splash-logo">
-      		<img src="/images/about_readium_logo.png">
+      		<img src="images/about_readium_logo.png">
       	</div>
       	<div class="about-message">
 	      	<span>{{{strings.i18n_html_readium_tm_a_project}}}</span>
       	</div>
       	<div>
-			     <img src="/images/partner_logos.png">
+			     <img src="images/partner_logos.png">
 		    </div>
         <div class="version">Version 2.12.3, released February 7, 2014</div>
       </div>

--- a/templates/empty-library.html
+++ b/templates/empty-library.html
@@ -2,5 +2,5 @@
 	<div id="empty-message">
 		{{strings.i18n_add_items}}
 	</div>
-	<img id="empty-message-arrow" src="/images/library_arrow.png">
+	<img id="empty-message-arrow" src="images/library_arrow.png">
 </div>

--- a/templates/settings-dialog.html
+++ b/templates/settings-dialog.html
@@ -53,14 +53,14 @@
                     <div role="radiogroup" aria-labelledby="setting-header-display-legend" class="row">
                         <div role="radio" id="one-up-option" class="col-xs-2 col-xs-offset-4">
                             
-                            <input name="display-format" value="single" type="radio"><img src="/images/ico_singlepage_up.png">
+                            <input name="display-format" value="single" type="radio"><img src="images/ico_singlepage_up.png">
                                 
                             
                             <span class="offscreen-text">{{strings.i18n_single_pages}}</span>
                         </div>
                         <div role="radio" id="two-up-option" class="col-xs-2">
                             
-                                <input name="display-format" value="double" type="radio"><img src="/images/ico_doublepage_up.png">
+                                <input name="display-format" value="double" type="radio"><img src="images/ico_doublepage_up.png">
                                 
                             
                             <span class="offscreen-text">{{strings.i18n_double_pages}}</span>


### PR DESCRIPTION
Hi!

Fixed some issues with absolute paths to icons.

Tested with both web-based readium-js-viewer and Readium Chrome Extension - everything seems to look OK.
