### PR TITLE
Single page view / synthetic-spread override on narrow screens (e.g. mobile devices in portrait mode)

### DIFF
--- a/lib/ReaderSettingsDialog.js
+++ b/lib/ReaderSettingsDialog.js
@@ -1,7 +1,7 @@
 define(['hgn!templates/settings-dialog.html', 'i18n/Strings'], function(SettingsDialog, Strings){
 	var defaultSettings = {
         fontSize: 100,
-        isSyntheticSpread: true,
+        isSyntheticSpread: window.innerWidth >= 800,
         columnGap: 60
     }
     


### PR DESCRIPTION
Default isSyntheticSpread to false for devices with smaller horizontal resolutions
