### PR TITLE
jQuery automatically adds vendor prefix to CSS3 rules

### DIFF
--- a/lib/Readium.js
+++ b/lib/Readium.js
@@ -4,7 +4,7 @@ This code is required to IE for console shim
 */
 
 (function(){
-    
+
 
     if (!console["debug"]) console.debug = console.log;
     if (!console["info"]) console.info = console.log;
@@ -174,7 +174,7 @@ define("readiumSDK", ["backbone"], (function (global) {
 				// Apparently:
 				//  * Opera returns -1px instead of none
 				//  * IE6 returns undefined instead of none
-				return {'width': (name === 'max' && (width === undefined || width === 'none' || num(width) === -1) && Number.MAX_VALUE) || num(width), 
+				return {'width': (name === 'max' && (width === undefined || width === 'none' || num(width) === -1) && Number.MAX_VALUE) || num(width),
 						'height': (name === 'max' && (height === undefined || height === 'none' || num(height) === -1) && Number.MAX_VALUE) || num(height)};
 			}
 		};
@@ -439,11 +439,11 @@ ReadiumSDK.Helpers.escapeJQuerySelector = function(sel) {
         //http://api.jquery.com/category/selectors/
         //!"#$%&'()*+,./:;<=>?@[\]^`{|}~
         // double backslash escape
-        
+
         if (!sel) return undefined;
-        
+
         var selector = sel.replace(/([;&,\.\+\*\~\?':"\!\^#$%@\[\]\(\)<=>\|\/\\{}`])/g, '\\$1');
-        
+
         // if (selector !== sel)
         // {
         //     console.debug("---- SELECTOR ESCAPED");
@@ -454,7 +454,7 @@ ReadiumSDK.Helpers.escapeJQuerySelector = function(sel) {
         // {
         //     console.debug("---- SELECTOR OKAY: " + sel);
         // }
-        
+
         return selector;
 };
     // TESTS BELOW ALL WORKING FINE :)
@@ -524,13 +524,13 @@ ReadiumSDK.Models.ViewerSettings = function(settingsData) {
 
     this.mediaOverlaysSkippables = [];
     this.mediaOverlaysEscapables = [];
-    
+
     this.mediaOverlaysEnableClick = true;
     this.mediaOverlaysRate = 1;
     this.mediaOverlaysVolume = 100;
-    
+
     this.mediaOverlaysSynchronizationGranularity = "";
-    
+
     this.isScrollViewDoc = false;
     this.isScrollViewContinuous = false;
 
@@ -681,7 +681,7 @@ ReadiumSDK.Collections.StyleCollection = function() {
     };
 
     this.removeStyle = function(selector) {
-        
+
         var count = _styles.length;
 
         for(var i = 0; i < count; i++) {
@@ -963,10 +963,10 @@ ReadiumSDK.Models.Spine = function(epubPackage, spineDTO) {
     };
 
     this.item = function(index) {
-		
+
 		if (isValidIndex(index))
         	return self.items[index];
-			
+
 		return undefined;
     };
 
@@ -1078,9 +1078,9 @@ define("spine", ["readiumSDK","spineItem"], (function (global) {
 ReadiumSDK.Models.Smil.SmilNode = function(parent) {
 
     this.parent = parent;
-    
+
     this.id = "";
-    
+
     //root node is a smil model
     this.getSmil = function() {
 
@@ -1091,7 +1091,7 @@ ReadiumSDK.Models.Smil.SmilNode = function(parent) {
 
         return node;
     };
-    
+
     this.hasAncestor = function(node)
     {
         var parent = this.parent;
@@ -1112,10 +1112,10 @@ ReadiumSDK.Models.Smil.SmilNode = function(parent) {
 ReadiumSDK.Models.Smil.TimeContainerNode = function(parent) {
 
     this.parent = parent;
-    
+
     this.children = undefined;
     this.index = undefined;
-    
+
     this.epubtype = "";
 
     this.isEscapable = function(userEscapables)
@@ -1154,7 +1154,7 @@ ReadiumSDK.Models.Smil.TimeContainerNode = function(parent) {
         {
             return false;
         }
-        
+
         var smilModel = this.getSmil();
         if (!smilModel.mo)
         {
@@ -1187,7 +1187,7 @@ ReadiumSDK.Models.Smil.TimeContainerNode.prototype = new ReadiumSDK.Models.Smil.
 ReadiumSDK.Models.Smil.MediaNode = function(parent) {
 
     this.parent = parent;
-    
+
     this.src = "";
 };
 
@@ -1199,17 +1199,17 @@ ReadiumSDK.Models.Smil.MediaNode.prototype = new ReadiumSDK.Models.Smil.SmilNode
 ReadiumSDK.Models.Smil.SeqNode = function(parent) {
 
     this.parent = parent;
-    
+
     this.children = [];
     this.nodeType = "seq";
     this.textref = "";
-    
+
     this.durationMilliseconds = function()
     {
         var smilData = this.getSmil();
-            
+
         var total = 0;
-        
+
         for (var i = 0; i < this.children.length; i++)
         {
             var container = this.children[i];
@@ -1225,7 +1225,7 @@ ReadiumSDK.Models.Smil.SeqNode = function(parent) {
 // console.log(smilData.spineItemId);
                     continue;
                 }
-                
+
                 var clipDur = container.audio.clipDurationMilliseconds();
                 total += clipDur;
             }
@@ -1237,11 +1237,11 @@ ReadiumSDK.Models.Smil.SeqNode = function(parent) {
 
         return total;
     };
-    
+
     this.clipOffset = function(offset, par)
     {
         var smilData = this.getSmil();
-        
+
         for (var i = 0; i < this.children.length; i++)
         {
             var container = this.children[i];
@@ -1281,7 +1281,7 @@ ReadiumSDK.Models.Smil.SeqNode = function(parent) {
     this.parallelAt = function(timeMilliseconds)
     {
         var smilData = this.getSmil();
-        
+
         var offset = 0;
 
         for (var i = 0; i < this.children.length; i++)
@@ -1289,7 +1289,7 @@ ReadiumSDK.Models.Smil.SeqNode = function(parent) {
             var timeAdjusted = timeMilliseconds - offset;
 
             var container = this.children[i];
-            
+
             if (container.nodeType === "par")
             {
                 if (!container.audio)
@@ -1331,7 +1331,7 @@ ReadiumSDK.Models.Smil.SeqNode = function(parent) {
         for (var i = 0; i < this.children.length; i++)
         {
             var container = this.children[i];
-            
+
             if (container.nodeType === "par")
             {
                 count.count++;
@@ -1353,7 +1353,7 @@ ReadiumSDK.Models.Smil.SeqNode = function(parent) {
 
         return undefined;
     };
-    
+
 };
 
 ReadiumSDK.Models.Smil.SeqNode.prototype = new ReadiumSDK.Models.Smil.TimeContainerNode();
@@ -1364,17 +1364,17 @@ ReadiumSDK.Models.Smil.SeqNode.prototype = new ReadiumSDK.Models.Smil.TimeContai
 ReadiumSDK.Models.Smil.ParNode = function(parent) {
 
     this.parent = parent;
-    
+
     this.children = [];
     this.nodeType = "par";
     this.text = undefined;
     this.audio = undefined;
     this.element = undefined;
-    
+
 
     this.getFirstSeqAncestorWithEpubType = function(epubtype, includeSelf) {
         if (!epubtype) return undefined;
-        
+
         var parent = includeSelf ? this : this.parent;
         while (parent)
         {
@@ -1382,10 +1382,10 @@ ReadiumSDK.Models.Smil.ParNode = function(parent) {
             {
                 return parent; // assert(parent.nodeType === "seq")
             }
-            
+
             parent = parent.parent;
         }
-        
+
         return undefined;
     };
 };
@@ -1402,22 +1402,22 @@ ReadiumSDK.Models.Smil.TextNode = function(parent) {
     this.nodeType = "text";
     this.srcFile = "";
     this.srcFragmentId = "";
-    
-    
+
+
     this.manifestItemId = undefined;
     this.updateMediaManifestItemId = function()
     {
         var smilData = this.getSmil();
-        
+
         if (!smilData.href || !smilData.href.length)
         {
             return; // Blank MO page placeholder, no real SMIL
         }
-        
+
         // var srcParts = item.src.split('#');
 //         item.srcFile = srcParts[0];
 //         item.srcFragmentId = (srcParts.length === 2) ? srcParts[1] : "";
-        
+
         var src = this.srcFile ? this.srcFile : this.src;
 // console.log("src: " + src);
 // console.log("smilData.href: " + smilData.href);
@@ -1439,12 +1439,12 @@ ReadiumSDK.Models.Smil.TextNode = function(parent) {
                 return;
             }
         }
-        
+
         console.error("Cannot set the Media ManifestItemId? " + this.src + " && " + smilData.href);
-        
+
 //        throw "BREAK";
     };
-    
+
 };
 
 ReadiumSDK.Models.Smil.TextNode.prototype = new ReadiumSDK.Models.Smil.MediaNode();
@@ -1462,20 +1462,20 @@ ReadiumSDK.Models.Smil.AudioNode = function(parent) {
 
     this.MAX = 1234567890.1; //Number.MAX_VALUE - 0.1; //Infinity;
     this.clipEnd = this.MAX;
-    
+
 
     this.clipDurationMilliseconds = function()
     {
         var _clipBeginMilliseconds = this.clipBegin * 1000;
         var _clipEndMilliseconds = this.clipEnd * 1000;
-        
+
         if (this.clipEnd >= this.MAX || _clipEndMilliseconds <= _clipBeginMilliseconds)
         {
             return 0;
         }
 
         return _clipEndMilliseconds - _clipBeginMilliseconds;
-    };  
+    };
 };
 
 ReadiumSDK.Models.Smil.AudioNode.prototype = new ReadiumSDK.Models.Smil.MediaNode();
@@ -1486,15 +1486,15 @@ ReadiumSDK.Models.Smil.AudioNode.prototype = new ReadiumSDK.Models.Smil.MediaNod
 ReadiumSDK.Models.SmilModel = function() {
 
     this.parent = undefined;
-    
-    
-    
+
+
+
     this.children = []; //collection of seq or par smil nodes
     this.id = undefined; //manifest item id
     this.href = undefined; //href of the .smil source file
     this.duration = undefined;
     this.mo = undefined;
-    
+
     this.parallelAt = function(timeMilliseconds)
     {
         return this.children[0].parallelAt(timeMilliseconds);
@@ -1516,15 +1516,15 @@ ReadiumSDK.Models.SmilModel = function() {
 
         return 0;
     };
-    
+
     this.durationMilliseconds_Calculated = function()
     {
         return this.children[0].durationMilliseconds();
     };
-    
+
 
     var _epubtypeSyncs = [];
-    // 
+    //
     // this.clearSyncs = function()
     // {
     //     _epubtypeSyncs = [];
@@ -1540,15 +1540,15 @@ ReadiumSDK.Models.SmilModel = function() {
                 return true;
             }
         }
-        
+
 //console.debug("hasSync??: ["+epubtype+"] " + _epubtypeSyncs);
         return false;
     };
-    
+
     this.addSync = function(epubtypes)
     {
         if (!epubtypes) return;
-        
+
 //console.debug("addSyncs: "+epubtypes);
 
         var parts = epubtypes.split(' ');
@@ -1564,7 +1564,7 @@ ReadiumSDK.Models.SmilModel = function() {
             }
         }
     };
-    
+
 };
 
 ReadiumSDK.Models.SmilModel.fromSmilDTO = function(smilDTO, mo) {
@@ -1589,16 +1589,16 @@ ReadiumSDK.Models.SmilModel.fromSmilDTO = function(smilDTO, mo) {
     smilModel.id = smilDTO.id;
     smilModel.spineItemId = smilDTO.spineItemId;
     smilModel.href = smilDTO.href;
-    
+
     smilModel.smilVersion = smilDTO.smilVersion;
-    
+
     smilModel.duration = smilDTO.duration;
     if (smilModel.duration && smilModel.duration.length && smilModel.duration.length > 0)
     {
         console.error("SMIL duration is string, parsing float... (" + smilModel.duration + ")");
         smilModel.duration = parseFloat(smilModel.duration);
     }
-    
+
     smilModel.mo = mo; //ReadiumSDK.Models.MediaOverlay
 
     if (smilModel.mo.DEBUG)
@@ -1652,7 +1652,7 @@ ReadiumSDK.Models.SmilModel.fromSmilDTO = function(smilDTO, mo) {
             {
                 node.getSmil().addSync(node.epubtype);
             }
-            
+
             indent++;
             copyChildren(nodeDTO, node);
             indent--;
@@ -1677,7 +1677,7 @@ ReadiumSDK.Models.SmilModel.fromSmilDTO = function(smilDTO, mo) {
             indent++;
             copyChildren(nodeDTO, node);
             indent--;
-			
+
             for(var i = 0, count = node.children.length; i < count; i++) {
                 var child = node.children[i];
 
@@ -1721,7 +1721,7 @@ var forceTTS = false; // for testing only!
             safeCopyProperty("srcFile", nodeDTO, node, true);
             safeCopyProperty("srcFragmentId", nodeDTO, node, false);
             safeCopyProperty("id", nodeDTO, node);
-            
+
             node.updateMediaManifestItemId();
         }
         else if (nodeDTO.nodeType == "audio") {
@@ -1765,8 +1765,8 @@ var forceTTS = false; // for testing only!
                 }
                 node.clipEnd = node.MAX;
             }
-            
-            //node.updateMediaManifestItemId(); ONLY XHTML SPINE ITEMS 
+
+            //node.updateMediaManifestItemId(); ONLY XHTML SPINE ITEMS
         }
         else {
             console.error("Unexpected smil node type: " + nodeDTO.nodeType);
@@ -1824,16 +1824,16 @@ define("smilModel", ["readiumSDK"], (function (global) {
 ReadiumSDK.Models.MediaOverlay = function(package) {
 
     this.package = package;
-    
+
 
     this.parallelAt = function(timeMilliseconds)
     {
         var offset = 0;
-        
+
         for (var i = 0; i < this.smil_models.length; i++)
         {
             var smilData = this.smil_models[i];
-            
+
             var timeAdjusted = timeMilliseconds - offset;
 
             var para = smilData.parallelAt(timeAdjusted);
@@ -1847,14 +1847,14 @@ ReadiumSDK.Models.MediaOverlay = function(package) {
 
         return undefined;
     };
-    
+
     this.percentToPosition = function(percent, smilData, par, milliseconds)
     {
         if (percent < 0.0 || percent > 100.0)
         {
             percent = 0.0;
         }
-            
+
         var total = this.durationMilliseconds_Calculated();
 
         var timeMs = total * (percent / 100.0);
@@ -1864,15 +1864,15 @@ ReadiumSDK.Models.MediaOverlay = function(package) {
         {
             return;
         }
-        
+
         var smilDataPar = par.par.getSmil();
         if (!smilDataPar)
         {
             return;
         }
-        
+
         var smilDataOffset = 0;
-        
+
         for (var i = 0; i < this.smil_models.length; i++)
         {
             smilData.smilData = this.smil_models[i];
@@ -1889,17 +1889,17 @@ ReadiumSDK.Models.MediaOverlay = function(package) {
     this.durationMilliseconds_Calculated = function()
     {
         var total = 0;
-        
+
         for (var i = 0; i < this.smil_models.length; i++)
         {
             var smilData = this.smil_models[i];
 
             total += smilData.durationMilliseconds_Calculated();
         }
-        
+
         return total;
     };
-    
+
     this.positionToPercent = function(smilIndex, parIndex, milliseconds)
     {
 // console.log(">>>>>>>>>>");
@@ -1907,7 +1907,7 @@ ReadiumSDK.Models.MediaOverlay = function(package) {
 // console.log(smilIndex);
 // console.log(parIndex);
 // console.log("-------");
-                
+
         if (smilIndex >= this.smil_models.length)
         {
             return -1.0;
@@ -1921,7 +1921,7 @@ ReadiumSDK.Models.MediaOverlay = function(package) {
         }
 
 //console.log(smilDataOffset);
-        
+
         var smilData = this.smil_models[smilIndex];
 
         var par = smilData.nthParallel(parIndex);
@@ -1933,7 +1933,7 @@ ReadiumSDK.Models.MediaOverlay = function(package) {
         var offset = smilDataOffset + smilData.clipOffset(par) + milliseconds;
 
 //console.log(offset);
-        
+
         var total = this.durationMilliseconds_Calculated();
 
 ///console.log(total);
@@ -1941,10 +1941,10 @@ ReadiumSDK.Models.MediaOverlay = function(package) {
         var percent = (offset / total) * 100;
 
 //console.log("<<<<<<<<<<< " + percent);
-        
+
         return percent;
       };
-      
+
     this.smil_models = [];
 
     this.skippables = [];
@@ -2027,7 +2027,7 @@ ReadiumSDK.Models.MediaOverlay.fromDTO = function(moDTO, package) {
 
     // if (mo.DEBUG)
     //     console.debug(JSON.stringify(moDTO));
-        
+
     mo.duration = moDTO.duration;
     if (mo.duration && mo.duration.length && mo.duration.length > 0)
     {
@@ -2164,7 +2164,7 @@ ReadiumSDK.Models.Package = function(packageData){
     this.isReflowable = function() {
         return !self.isFixedLayout();
     };
-    
+
 
     if(packageData) {
 
@@ -2176,15 +2176,15 @@ ReadiumSDK.Models.Package = function(packageData){
         if(!this.rendition_layout) {
             this.rendition_layout = "reflowable";
         }
-        
+
         this.rendition_flow = packageData.rendition_flow;
-        
+
         this.spine = new ReadiumSDK.Models.Spine(this, packageData.spine);
 
         this.media_overlay = ReadiumSDK.Models.MediaOverlay.fromDTO(packageData.media_overlay, this);
-        
+
     }
-    
+
 };
 
 define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
@@ -2225,7 +2225,7 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
     var DEBUG = false;
 
     var _audioElement = new Audio();
-    
+
     if (DEBUG)
     {
         _audioElement.addEventListener("load", function()
@@ -2310,11 +2310,11 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
     ReadiumSDK.Views.AudioPlayer = function(onStatusChanged, onPositionChanged, onAudioEnded, onAudioPlay, onAudioPause)
     {
         var self = this;
-     
+
         //_audioElement.setAttribute("preload", "auto");
-    
+
         var _currentEpubSrc = undefined;
-    
+
         var _currentSmilSrc = undefined;
         this.currentSmilSrc = function() {
             return _currentSmilSrc;
@@ -2332,7 +2332,7 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
             {
                 _rate = 4.0;
             }
-    
+
             _audioElement.playbackRate = _rate;
         }
         self.setRate(_rate);
@@ -2340,8 +2340,8 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
         {
             return _rate;
         }
-    
-    
+
+
         var _volume = 100.0;
         this.setVolume = function(volume)
         {
@@ -2361,57 +2361,57 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
         {
             return _volume;
         }
-    
+
         this.play = function()
         {
             if (DEBUG)
             {
                 console.error("this.play()");
             }
-    
+
             if(!_currentEpubSrc)
             {
                 return false;
             }
-    
+
             startTimer();
-    
+
             self.setVolume(_volume);
             self.setRate(_rate);
-    
+
             _audioElement.play();
-    
+
             return true;
         };
-    
+
         this.pause = function()
         {
             if (DEBUG)
             {
                 console.error("this.pause()");
             }
-    
+
             stopTimer();
-    
+
             _audioElement.pause();
         };
-    
+
         _audioElement.addEventListener('play', onPlay, false);
         _audioElement.addEventListener('pause', onPause, false);
         _audioElement.addEventListener('ended', onEnded, false);
-    
+
         function onPlay()
         {
             onStatusChanged({isPlaying: true});
             onAudioPlay();
         }
-    
+
         function onPause()
         {
             onAudioPause();
             onStatusChanged({isPlaying: false});
         }
-    
+
         function onEnded()
         {
             if (_audioElement.moSeeking)
@@ -2420,18 +2420,18 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
                 {
                     console.debug("onEnded() skipped (still seeking...)");
                 }
-    
+
                 return;
             }
-    
+
             stopTimer();
-    
+
             onAudioEnded();
             onStatusChanged({isPlaying: false});
         }
-        
+
         var _intervalTimerSkips = 0;
-        
+
         var _intervalTimer = undefined;
         function startTimer()
         {
@@ -2439,7 +2439,7 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
             {
                 return;
             }
-    
+
             _intervalTimer = setInterval(
                 function()
                 {
@@ -2449,7 +2449,7 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
                         {
                             console.debug("interval timer skipped (still seeking...)");
                         }
-                                         
+
                         _intervalTimerSkips++;
                         if (_intervalTimerSkips > 1000)
                         {
@@ -2458,18 +2458,18 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
                         }
                         return;
                     }
-    
+
                     var currentTime = _audioElement.currentTime;
-    
+
     //                if (DEBUG)
     //                {
     //                    console.debug("currentTime: " + currentTime);
     //                }
-    
+
                     onPositionChanged(currentTime, 1);
                 }, 20);
         }
-    
+
         function stopTimer()
         {
             if (_intervalTimer)
@@ -2478,32 +2478,32 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
             }
             _intervalTimer = undefined;
         }
-    
+
         this.isPlaying = function()
         {
             return _intervalTimer !== undefined;
         };
-    
+
         this.reset = function()
         {
             if (DEBUG)
             {
                 console.error("this.reset()");
             }
-    
+
             this.pause();
-    
+
             _audioElement.moSeeking = undefined;
-    
+
             _currentSmilSrc = undefined;
             _currentEpubSrc = undefined;
-    
+
             setTimeout(function()
             {
                 _audioElement.setAttribute("src", "");
             }, 1);
         };
-    
+
 
         _audioElement.addEventListener("loadstart", function()
             {
@@ -2517,24 +2517,24 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
             {
                 return false;
             }
-    
+
             if (_touchInited)
             {
                 return false;
             }
-    
+
             _touchInited = true;
-    
+
             _audioElement.setAttribute("src", "touch/init/html5/audio.mp3");
             _audioElement.load();
-    
+
             return true;
         }
-    
+
         var _playId = 0;
-    
+
         var _seekQueuing = 0;
-        
+
         this.playFile = function(smilSrc, epubSrc, seekBegin) //element
         {
             _playId++;
@@ -2542,9 +2542,9 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
             {
                 _playId = 0;
             }
-    
+
             var playId = _playId;
-    
+
             if (_audioElement.moSeeking)
             {
                 _seekQueuing++;
@@ -2553,107 +2553,107 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
                     _seekQueuing = 0;
                     return;
                 }
-                
+
                 if (DEBUG)
                 {
                     console.debug("this.playFile(" + epubSrc + ")" + " @" + seekBegin + " (POSTPONE, SEEKING...)");
                 }
-    
+
                 setTimeout(function()
                 {
                     self.playFile(smilSrc, epubSrc, seekBegin);
                 }, 20);
-                
+
                 return;
             }
-    
+
             _audioElement.moSeeking = {};
-    
+
             if (DEBUG)
             {
                 console.debug("this.playFile(" + epubSrc + ")" + " @" + seekBegin + " #" + playId);
             }
-    
+
             var audioNeedsNewSrc = !_currentEpubSrc || _currentEpubSrc !== epubSrc;
-    
+
             if (!audioNeedsNewSrc)
             {
                 if (DEBUG)
                 {
                     console.debug("this.playFile() SAME SRC");
                 }
-    
+
                 this.pause();
-    
+
                 _currentSmilSrc = smilSrc;
                 _currentEpubSrc = epubSrc;
-    
+
                 playSeekCurrentTime(seekBegin, playId, false);
-    
+
                 return;
             }
-    
+
             if (DEBUG)
             {
                 console.debug("this.playFile() NEW SRC");
                 console.debug("_currentEpubSrc: " + _currentEpubSrc);
                 console.debug("epubSrc: " + epubSrc);
             }
-    
+
             this.reset();
             _audioElement.moSeeking = {};
-    
+
             _currentSmilSrc = smilSrc;
             _currentEpubSrc = epubSrc;
-    
+
             //element.parentNode.insertBefore(_audioElement, element); //element.parentNode.childNodes[0]);
-            
+
             if (!_Android)
             {
                 _audioElement.addEventListener('play', onPlayToForcePreload, false);
             }
-    
+
             $(_audioElement).on(_readyEvent, {seekBegin: seekBegin, playId: playId}, onReadyToSeek);
-            
+
             setTimeout(function()
             {
                    _audioElement.setAttribute("src", _currentEpubSrc);
                    // _audioElement.src = _currentEpubSrc;
                    // $(_audioElement).attr("src", _currentEpubSrc);
-    
+
                    // if (_Android)
                    // {
                    //     _audioElement.addEventListener('loadstart', onReadyToPlayToForcePreload, false);
                    // }
-                   
+
                    _audioElement.load();
-    
+
                    if (!_Android)
                    {
                        playToForcePreload();
                    }
             }, 1);
         };
-    
+
         // var onReadyToPlayToForcePreload = function ()
         // {
         //     _audioElement.removeEventListener('loadstart', onReadyToPlayToForcePreload, false);
-        //     
+        //
         //     if (DEBUG)
         //     {
         //         console.debug("onReadyToPlayToForcePreload");
         //     }
-        //     
+        //
         //     playToForcePreload();
         // };
-        
+
         var playToForcePreload = function()
         {
             if (DEBUG)
             {
                 console.debug("playToForcePreload");
             }
-            
+
             //_audioElement.volume = 0;
             //_audioElement.play();
             var vol = _volume;
@@ -2661,65 +2661,65 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
             self.play();
             _volume = vol;
         };
-    
+
         var onPlayToForcePreload = function ()
         {
             _audioElement.removeEventListener('play', onPlayToForcePreload, false);
-            
+
             if (DEBUG)
             {
                 console.debug("onPlayToForcePreload");
             }
             _audioElement.pause(); // note: interval timer continues (immediately follows self.play())
         };
-    
+
         var _readyEvent = _Android ? "canplaythrough" : "canplay";
         function onReadyToSeek(event)
         {
             $(_audioElement).off(_readyEvent, onReadyToSeek);
-            
+
             if (DEBUG)
             {
                 console.debug("onReadyToSeek #" + event.data.playId);
             }
             playSeekCurrentTime(event.data.seekBegin, event.data.playId, true);
         }
-    
+
         function playSeekCurrentTime(newCurrentTime, playId, isNewSrc)
         {
             if (DEBUG)
             {
                 console.debug("playSeekCurrentTime() #" + playId);
             }
-    
+
             if (newCurrentTime == 0)
             {
                 newCurrentTime = 0.01;
             }
-    
+
             if(Math.abs(newCurrentTime - _audioElement.currentTime) < 0.3)
             {
                 if (DEBUG)
                 {
                     console.debug("playSeekCurrentTime() CONTINUE");
                 }
-    
+
                 _audioElement.moSeeking = undefined;
                 self.play();
                 return;
             }
-    
+
             var ev = isNewSrc ? _seekedEvent1 : _seekedEvent2;
-    
+
             if (DEBUG)
             {
                 console.debug("playSeekCurrentTime() NEED SEEK, EV: " + ev);
             }
-    
+
             self.pause();
-    
+
             $(_audioElement).on(ev, {newCurrentTime: newCurrentTime, playId: playId, isNewSrc: isNewSrc}, onSeeked);
-    
+
             try
             {
                 _audioElement.currentTime = newCurrentTime;
@@ -2727,7 +2727,7 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
             catch (ex)
             {
                 console.error(ex.message);
-    
+
                 setTimeout(function()
                 {
                     try
@@ -2741,29 +2741,29 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
                 }, 5);
             }
         }
-    
+
         var MAX_SEEK_RETRIES = 10;
         var _seekedEvent1 = _iOS ? "canplaythrough" : "seeked"; //"progress"
         var _seekedEvent2 = _iOS ? "timeupdate" : "seeked";
         function onSeeked(event)
         {
             var ev = event.data.isNewSrc ? _seekedEvent1 : _seekedEvent2;
-    
+
             var notRetry = event.data.seekRetries == undefined;
-    
+
             if (notRetry || event.data.seekRetries == MAX_SEEK_RETRIES) // first retry
             {
                 $(_audioElement).off(ev, onSeeked);
             }
-    
+
             if (DEBUG)
             {
                 console.debug("onSeeked() #" + event.data.playId + " FIRST? " + notRetry + " EV: " + ev);
             }
-    
+
             var curTime = _audioElement.currentTime;
             var diff = Math.abs(event.data.newCurrentTime - curTime);
-    
+
             if((notRetry || event.data.seekRetries >= 0) &&
                 diff >= 1)
             {
@@ -2771,35 +2771,35 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
                 {
                     console.debug("onSeeked() time diff: " + event.data.newCurrentTime + " vs. " + curTime + " ("+diff+")");
                 }
-                
+
                 if (notRetry)
                 {
                     event.data.seekRetries = MAX_SEEK_RETRIES;
-    
+
                     // if (DEBUG)
                     // {
                     //     console.debug("onSeeked() fail => first retry, EV: " + _seekedEvent2);
                     // }
-    
+
                     event.data.isNewSrc = false;
                     //$(_audioElement).on(_seekedEvent2, event.data, onSeeked);
                 }
-                
+
                 //else
                 {
                     event.data.seekRetries--;
-    
+
                     if (DEBUG)
                     {
                         console.debug("onSeeked() FAIL => retry again (timeout)");
                     }
-    
+
                     setTimeout(function()
                     {
                         onSeeked(event);
                     }, 50);
                 }
-    
+
                 setTimeout(function()
                 {
                     try
@@ -2813,7 +2813,7 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
                     catch (ex)
                     {
                         console.error(ex.message);
-    
+
                         setTimeout(function()
                         {
                             try
@@ -2841,25 +2841,25 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
                     console.debug(event.data.seekRetries);
                     console.debug(diff);
                 }
-    
+
                 if (diff >= 1)
                 {
                     if (DEBUG)
                     {
                         console.debug("onSeeked() ABORT, TRY AGAIN FROM SCRATCH!");
                     }
-                    
+
                     var smilSrc = _currentSmilSrc;
                     var epubSrc = _currentEpubSrc;
                     var seekBegin = event.data.newCurrentTime;
-                    
+
                     self.reset();
-                    
+
                     setTimeout(function()
                     {
                         self.playFile(smilSrc, epubSrc, seekBegin);
                     }, 10);
-                    
+
                     return;
                 }
 
@@ -2867,11 +2867,11 @@ define("package", ["readiumSDK","spine","mediaOverlay"], (function (global) {
                 {
                     console.debug("onSeeked() OKAY => play!");
                 }
-                
+
                 event.data.seekRetries = undefined;
-    
+
                 self.play();
-    
+
                 _audioElement.moSeeking = undefined;
             }
         }
@@ -2898,7 +2898,7 @@ define("audioPlayer", ["readiumSDK"], (function (global) {
 
 
 define('domReady',[],function () {
-    
+
 
     var isTop, testDiv, scrollIntervalId,
         isBrowser = typeof window !== "undefined" && window.document,
@@ -3334,11 +3334,11 @@ define('domReady',[],function () {
                     throw new Error("required module '" + moduleName + "' not supported");
                 }
             }
-            
+
             // Now run initializer
             this.initializer(this)
         },
-        
+
         fail: function(reason) {
             this.initialized = true;
             this.supported = false;
@@ -3358,7 +3358,7 @@ define('domReady',[],function () {
             return new Error("Error in Rangy " + this.name + " module: " + msg);
         }
     };
-    
+
     function createModule(isCore, name, dependencies, initFunc) {
         var newModule = new Module(name, dependencies, function(module) {
             if (!module.initialized) {
@@ -3373,12 +3373,12 @@ define('domReady',[],function () {
             }
         });
         modules[name] = newModule;
-        
+
 /*
         // Add module AMD support
         if (!isCore && amdSupported) {
             global.define(["rangy-core"], function(rangy) {
-                
+
             });
         }
 */
@@ -3445,7 +3445,7 @@ define('domReady',[],function () {
     addListener(window, "load", loadHandler);
 
     /*----------------------------------------------------------------------------------------------------------------*/
-    
+
     // AMD, for those who like this kind of thing
 
     /*
@@ -3460,7 +3460,7 @@ define('domReady',[],function () {
     // Create a "rangy" property of the global object in any case. Other Rangy modules (which use Rangy's own simple
     // module system) rely on the existence of this global property
     global.rangy = api;
-})(this);    
+})(this);
 
 rangy.createCoreModule("DomUtil", [], function(api, module) {
     var UNDEF = "undefined";
@@ -4761,7 +4761,7 @@ rangy.createCoreModule("DomRange", ["DomUtil"], function(api, module) {
             this.setStartAfter(node);
             this.collapse(true);
         },
-        
+
         getBookmark: function(containerNode) {
             var doc = getRangeDocument(this);
             var preSelectionRange = api.createRange(doc);
@@ -4782,7 +4782,7 @@ rangy.createCoreModule("DomRange", ["DomUtil"], function(api, module) {
                 containerNode: containerNode
             };
         },
-        
+
         moveToBookmark: function(bookmark) {
             var containerNode = bookmark.containerNode;
             var charIndex = 0;
@@ -4824,7 +4824,7 @@ rangy.createCoreModule("DomRange", ["DomUtil"], function(api, module) {
         isValid: function() {
             return isRangeValid(this);
         },
-        
+
         inspect: function() {
             return inspect(this);
         }
@@ -4966,7 +4966,7 @@ rangy.createCoreModule("DomRange", ["DomUtil"], function(api, module) {
 
                 boundaryUpdater(this, sc, so, ec, eo);
             },
-            
+
             setBoundary: function(node, offset, isStart) {
                 this["set" + (isStart ? "Start" : "End")](node, offset);
             },
@@ -5447,7 +5447,7 @@ rangy.createCoreModule("WrappedRange", ["DomRange"], function(api, module) {
             };
         })();
     }
-    
+
     if (api.features.implementsTextRange) {
         /*
         This is a workaround for a bug where IE returns the wrong container element from the TextRange's parentElement()
@@ -5569,11 +5569,11 @@ rangy.createCoreModule("WrappedRange", ["DomRange"], function(api, module) {
                     For the particular case of a boundary within a text node containing rendered line breaks (within a <pre>
                     element, for example), we need a slightly complicated approach to get the boundary's offset in IE. The
                     facts:
-                    
+
                     - Each line break is represented as \r in the text node's data/nodeValue properties
                     - Each line break is represented as \r\n in the TextRange's 'text' property
                     - The 'text' property of the TextRange does not contain trailing line breaks
-                    
+
                     To get round the problem presented by the final fact above, we can use the fact that TextRange's
                     moveStart() and moveEnd() methods return the actual number of characters moved, which is not necessarily
                     the same as the number of characters it was instructed to move. The simplest approach is to use this to
@@ -5582,13 +5582,13 @@ rangy.createCoreModule("WrappedRange", ["DomRange"], function(api, module) {
                     However, this is extremely slow when the document is large and the range is near the end of it. Clearly
                     doing the mirror image (i.e. moving the range boundaries to the end of the document) has the same
                     problem.
-                    
+
                     Another approach that works is to use moveStart() to move the start boundary of the range up to the end
                     boundary one character at a time and incrementing a counter with the value returned by the moveStart()
                     call. However, the check for whether the start boundary has reached the end boundary is expensive, so
                     this method is slow (although unlike "move-negative-gazillion" is largely unaffected by the location of
                     the range within the document).
-                    
+
                     The method below is a hybrid of the two methods above. It uses the fact that a string containing the
                     TextRange's 'text' property with each \r\n converted to a single \r character cannot be longer than the
                     text of the TextRange, so the start of the range is moved that length initially and then a character at
@@ -5835,7 +5835,7 @@ rangy.createCoreModule("WrappedSelection", ["DomRange", "WrappedRange"], functio
     function getDocSelection(winParam) {
         return getWindow(winParam, "getDocSelection").document.selection;
     }
-    
+
     function winSelectionIsBackward(sel) {
         var backward = false;
         if (sel.anchorNode) {
@@ -5886,7 +5886,7 @@ rangy.createCoreModule("WrappedSelection", ["DomRange", "WrappedRange"], functio
     // Test for existence of native selection extend() method
     var selectionHasExtend = isHostMethod(testSelection, "extend");
     features.selectionHasExtend = selectionHasExtend;
-    
+
     // Test if rangeCount exists
     var selectionHasRangeCount = (typeof testSelection.rangeCount == NUMBER);
     features.selectionHasRangeCount = selectionHasRangeCount;
@@ -5920,11 +5920,11 @@ rangy.createCoreModule("WrappedSelection", ["DomRange", "WrappedRange"], functio
                 var originalSelectionRangeCount = sel.rangeCount;
                 var selectionHasMultipleRanges = (originalSelectionRangeCount > 1);
                 var originalSelectionRanges = [];
-                var originalSelectionBackward = winSelectionIsBackward(sel); 
+                var originalSelectionBackward = winSelectionIsBackward(sel);
                 for (var i = 0; i < originalSelectionRangeCount; ++i) {
                     originalSelectionRanges[i] = sel.getRangeAt(i);
                 }
-                
+
                 // Create some test elements
                 var body = getBody(document);
                 var testEl = body.appendChild( document.createElementNS("http://www.w3.org/1999/xhtml", "div") );
@@ -6636,7 +6636,7 @@ rangy.createCoreModule("WrappedSelection", ["DomRange", "WrappedRange"], functio
         } );
         return results;
     };
-    
+
     function createStartOrEndSetter(isStart) {
         return function(node, offset) {
             var range;
@@ -6653,7 +6653,7 @@ rangy.createCoreModule("WrappedSelection", ["DomRange", "WrappedRange"], functio
 
     selProto.setStart = createStartOrEndSetter(true);
     selProto.setEnd = createStartOrEndSetter(false);
-    
+
     // Add select() method to Range prototype. Any existing selection will be removed.
     api.rangePrototype.select = function(direction) {
         getSelection( this.getDocument() ).setSingleRange(this, direction);
@@ -6849,7 +6849,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
         union: function(charRange) {
             return new CharacterRange(Math.min(this.start, charRange.start), Math.max(this.end, charRange.end));
         },
-        
+
         intersection: function(charRange) {
             return new CharacterRange(Math.max(this.start, charRange.start), Math.min(this.end, charRange.end));
         },
@@ -6976,7 +6976,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
         getContainerElement: function() {
             return this.containerElementId ? this.doc.getElementById(this.containerElementId) : getBody(this.doc);
         },
-        
+
         getRange: function() {
             return this.converter.characterRangeToRange(this.doc, this.characterRange, this.getContainerElement());
         },
@@ -6984,7 +6984,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
         fromRange: function(range) {
             this.characterRange = this.converter.rangeToCharacterRange(range, this.getContainerElement());
         },
-        
+
         getText: function() {
             return this.getRange().toString();
         },
@@ -7002,7 +7002,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
             this.classApplier.applyToRange(this.getRange());
             this.applied = true;
         },
-        
+
         getHighlightElements: function() {
             return this.classApplier.getElementsWithClassIntersectingRange(this.getRange());
         },
@@ -7066,7 +7066,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
 
             return intersectingHighlights;
         },
-        
+
         highlightCharacterRanges: function(className, charRanges, containerElementId) {
             var i, len, j;
             var highlights = this.highlights;
@@ -7116,7 +7116,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
                     highlights.push( new Highlight(doc, charRange, classApplier, converter, null, containerElementId) );
                 }
             }
-            
+
             // Remove the old highlights
             forEach(highlightsToRemove, function(highlightToRemove) {
                 highlightToRemove.unapply();
@@ -7130,7 +7130,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
                     newHighlights.push(highlight);
                 }
             });
-            
+
             return newHighlights;
         },
 
@@ -7142,13 +7142,13 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
             if (containerElement) {
                 containerElementRange = api.createRange(containerElement);
                 containerElementRange.selectNodeContents(containerElement);
-            } 
+            }
 
             forEach(ranges, function(range) {
                 var scopedRange = containerElement ? containerElementRange.intersection(range) : range;
                 selCharRanges.push( converter.rangeToCharacterRange(scopedRange, containerElement || getBody(range.getDocument())) );
             });
-            
+
             return this.highlightCharacterRanges(selCharRanges, ranges, containerElementId);
         },
 
@@ -7171,7 +7171,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
             forEach(serializedSelection, function(rangeInfo) {
                 selCharRanges.push( CharacterRange.fromCharacterRange(rangeInfo.characterRange) );
             });
-            
+
             var newHighlights = this.highlightCharacterRanges(className, selCharRanges, containerElementId);
 
             // Restore selection
@@ -7237,7 +7237,7 @@ rangy.createModule("Highlighter", ["ClassApplier"], function(api, module) {
             } else {
                 throw new Error("Serialized highlights are invalid.");
             }
-            
+
             var classApplier, highlight, characterRange, containerElementId, containerElement;
 
             for (var i = serializedHighlights.length, parts; i-- > 0; ) {
@@ -7308,7 +7308,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
         }
         return true;
     }
-    
+
     function trim(str) {
         return str.replace(/^\s\s*/, "").replace(/\s\s*$/, "");
     }
@@ -7371,7 +7371,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
         position.node = newNode;
         position.offset = newOffset;
     }
-    
+
     function movePositionWhenRemovingNode(position, parentNode, index) {
         if (position.node == parentNode && position.offset > index) {
             --position.offset;
@@ -7398,7 +7398,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
             newParent.insertBefore(node, newParent.childNodes[newIndex]);
         }
     }
-    
+
     function removePreservingPositions(node, positionsToPreserve) {
 
         var oldParent = node.parentNode;
@@ -7440,9 +7440,9 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
 
     function getEffectiveTextNodes(range) {
         var nodes = range.getNodes([3]);
-        
+
         // Optimization as per issue 145
-        
+
         // Remove non-intersecting text nodes from the start of the range
         var start = 0, node;
         while ( (node = nodes[start]) && !rangeSelectsAnyText(range, node) ) {
@@ -7454,7 +7454,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
         while ( (node = nodes[end]) && !rangeSelectsAnyText(range, node) ) {
             --end;
         }
-        
+
         return nodes.slice(start, end + 1);
     }
 
@@ -7860,7 +7860,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
 
             return createCopy ? elProps : "";
         },
-        
+
         copyAttributesToElement: function(attrs, el) {
             for (var attrName in attrs) {
                 if (attrs.hasOwnProperty(attrName)) {
@@ -7990,16 +7990,16 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
                 && this.isRemovable(el)
                 && (childNodeCount == 0 || (childNodeCount == 1 && this.isEmptyContainer(el.firstChild)));
         },
-        
+
         removeEmptyContainers: function(range) {
             var applier = this;
             var nodesToRemove = range.getNodes([1], function(el) {
                 return applier.isEmptyContainer(el);
             });
-            
+
             var rangesToPreserve = [range]
             var positionsToPreserve = getRangeBoundaries(rangesToPreserve);
-            
+
             for (var i = 0, node; node = nodesToRemove[i++]; ) {
                 removePreservingPositions(node, positionsToPreserve);
             }
@@ -8034,10 +8034,10 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
 
             // Create an array of range boundaries to preserve
             var positionsToPreserve = getRangeBoundaries(rangesToPreserve || []);
-            
+
             range.splitBoundariesPreservingPositions(positionsToPreserve);
 
-            // Tidy up the DOM by removing empty containers 
+            // Tidy up the DOM by removing empty containers
             if (this.removeEmptyElements) {
                 this.removeEmptyContainers(range);
             }
@@ -8086,7 +8086,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
 
             range.splitBoundariesPreservingPositions(positionsToPreserve);
 
-            // Tidy up the DOM by removing empty containers 
+            // Tidy up the DOM by removing empty containers
             if (this.removeEmptyElements) {
                 this.removeEmptyContainers(range, positionsToPreserve);
             }
@@ -8207,7 +8207,7 @@ rangy.createModule("ClassApplier", ["WrappedSelection"], function(api, module) {
                 this.applyToSelection(win);
             }
         },
-        
+
         getElementsWithClassIntersectingRange: function(range) {
             var elements = [];
             var applier = this;
@@ -8449,7 +8449,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
         includeSpaceBeforeBlock: !trailingSpaceBeforeBlockCollapses,
         includePreLineTrailingSpace: true
     };
-    
+
     var defaultWordOptions = {
         "en": {
             wordRegex: /[a-z0-9]+('[a-z0-9]+)*/gi,
@@ -8489,7 +8489,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
     function createCaretCharacterOptions(options) {
         return createOptions(options, defaultCaretCharacterOptions);
     }
-    
+
     var defaultFindOptions = {
         caseSensitive: false,
         withinRange: null,
@@ -8739,7 +8739,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
     };
 
     var cachedCount = 0, uncachedCount = 0;
-    
+
     function createCachingGetter(methodName, func, objProperty) {
         return function(args) {
             var cache = this.cache;
@@ -8754,7 +8754,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
             }
         };
     }
-    
+
 /*
     api.report = function() {
         console.log("Cached: " + cachedCount + ", uncached: " + uncachedCount);
@@ -8878,9 +8878,9 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
 
             return false;
         }, "node"),
-        
+
         isRenderedBlock: createCachingGetter("isRenderedBlock", function(el) {
-            // Ensure that a block element containing a <br> is considered to have inner text 
+            // Ensure that a block element containing a <br> is considered to have inner text
             var brs = el.getElementsByTagName("br");
             for (var i = 0, len = brs.length; i < len; ++i) {
                 if (!isCollapsedNode(brs[i])) {
@@ -9060,7 +9060,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
                 this.checkForLeadingSpace = false;
             }
         },
-        
+
         getPrecedingUncollapsedPosition: function(characterOptions) {
             var pos = this, character;
             while ( (pos = pos.previousVisible()) ) {
@@ -9075,27 +9075,27 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
 
         getCharacter: function(characterOptions) {
             this.resolveLeadingAndTrailingSpaces();
-            
+
             // Check if this position's  character is invariant (i.e. not dependent on character options) and return it
             // if so
             if (this.isCharInvariant) {
                 return this.character;
             }
-            
+
             var cacheKey = ["character", characterOptions.includeSpaceBeforeBr, characterOptions.includeBlockContentTrailingSpace, characterOptions.includePreLineTrailingSpace].join("_");
             var cachedChar = this.cache.get(cacheKey);
             if (cachedChar !== null) {
                 return cachedChar;
             }
-            
+
             // We need to actually get the character
             var character = "";
             var collapsible = (this.characterType == COLLAPSIBLE_SPACE);
-            
+
             var nextPos, previousPos/* = this.getPrecedingUncollapsedPosition(characterOptions)*/;
             var gotPreviousPos = false;
             var pos = this;
-            
+
             function getPreviousPos() {
                 if (!gotPreviousPos) {
                     previousPos = pos.getPrecedingUncollapsedPosition(characterOptions);
@@ -9126,7 +9126,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
                         } else if (nextPos.isLeadingSpace && nextPos.character == "\n") {
                             this.type = TRAILING_SPACE_BEFORE_BLOCK;
                         }
-                        
+
                         if (nextPos.character === "\n") {
                             if (this.type == TRAILING_SPACE_BEFORE_BR && !characterOptions.includeSpaceBeforeBr) {
                             } else if (this.type == TRAILING_SPACE_BEFORE_BLOCK && !characterOptions.includeSpaceBeforeBlock) {
@@ -9137,7 +9137,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
                                     if (this.isTrailingSpace) {
                                     } else if (this.isBr) {
                                         nextPos.type = TRAILING_LINE_BREAK_AFTER_BR;
-                                        
+
                                         if (getPreviousPos() && previousPos.isLeadingSpace && previousPos.character == "\n") {
                                             nextPos.character = "";
                                         } else {
@@ -9168,8 +9168,8 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
             else if (this.character === "\n" &&
                     (!(nextPos = this.nextUncollapsed()) || nextPos.isTrailingSpace)) {
             }
-            
-            
+
+
             this.cache.set(cacheKey, character);
 
             return character;
@@ -9514,7 +9514,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
 
             while ( (pos = it.next()) ) {
                 textChar = pos.character;
-                
+
 
                 if (allWhiteSpaceRegex.test(textChar)) {
                     if (insideWord) {
@@ -9722,7 +9722,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
                 chars.push(pos);
                 text += currentChar;
             }
-            
+
             //console.log("text " + text)
 
             if (isRegex) {
@@ -9937,7 +9937,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
                     startIndex = rangeBetween.text(characterOptions).length;
                 }
                 endIndex = startIndex + this.text(characterOptions).length;
-    
+
                 return {
                     start: startIndex,
                     end: endIndex
@@ -9949,24 +9949,24 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
             function(session, searchTermParam, findOptions) {
                 // Set up options
                 findOptions = createOptions(findOptions, defaultFindOptions);
-    
+
                 // Create word options if we're matching whole words only
                 if (findOptions.wholeWordsOnly) {
                     findOptions.wordOptions = createWordOptions(findOptions.wordOptions);
-    
+
                     // We don't ever want trailing spaces for search results
                     findOptions.wordOptions.includeTrailingSpace = false;
                 }
-    
+
                 var backward = isDirectionBackward(findOptions.direction);
-    
+
                 // Create a range representing the search scope if none was provided
                 var searchScopeRange = findOptions.withinRange;
                 if (!searchScopeRange) {
                     searchScopeRange = api.createRange();
                     searchScopeRange.selectNodeContents(this.getDocument());
                 }
-    
+
                 // Examine and prepare the search term
                 var searchTerm = searchTermParam, isRegex = false;
                 if (typeof searchTerm == "string") {
@@ -9976,26 +9976,26 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
                 } else {
                     isRegex = true;
                 }
-    
+
                 var initialPos = session.getRangeBoundaryPosition(this, !backward);
-    
+
                 // Adjust initial position if it lies outside the search scope
                 var comparison = searchScopeRange.comparePoint(initialPos.node, initialPos.offset);
-                
+
                 if (comparison === -1) {
                     initialPos = session.getRangeBoundaryPosition(searchScopeRange, true);
                 } else if (comparison === 1) {
                     initialPos = session.getRangeBoundaryPosition(searchScopeRange, false);
                 }
-    
+
                 var pos = initialPos;
                 var wrappedAround = false;
-    
+
                 // Try to find a match and ignore invalid ones
                 var findResult;
                 while (true) {
                     findResult = findTextFromPosition(pos, searchTerm, isRegex, searchScopeRange, findOptions);
-    
+
                     if (findResult) {
                         if (findResult.valid) {
                             this.setStartAndEnd(findResult.startPos.node, findResult.startPos.offset, findResult.endPos.node, findResult.endPos.offset);
@@ -10088,9 +10088,9 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
             function(session, containerNode, characterOptions) {
                 var ranges = this.getAllRanges(), rangeCount = ranges.length;
                 var rangeInfos = [];
-    
+
                 var backward = rangeCount == 1 && this.isBackward();
-    
+
                 for (var i = 0, len = ranges.length; i < len; ++i) {
                     rangeInfos[i] = {
                         characterRange: ranges[i].toCharacterRange(containerNode, characterOptions),
@@ -10098,7 +10098,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
                         characterOptions: characterOptions
                     };
                 }
-    
+
                 return rangeInfos;
             }
         ),
@@ -10161,7 +10161,7 @@ rangy.createModule("TextRange", ["WrappedSelection"], function(api, module) {
     };
 
     /*----------------------------------------------------------------------------------------------------------------*/
-    
+
     api.noMutation = function(func) {
         var session = getSession();
         func(session);
@@ -10209,7 +10209,7 @@ rangy.createModule("Position", ["WrappedSelection"], function(api, module) {
     var WrappedRange = api.WrappedRange;
     var WrappedTextRange = api.WrappedTextRange;
     var dom = api.dom, util = api.util, DomPosition = dom.DomPosition;
-    
+
     // Feature detection
 
     //var caretPositionFromPointSupported = (typeof document.caretPositionFromPoint != UNDEF);
@@ -10296,7 +10296,7 @@ rangy.createModule("Position", ["WrappedSelection"], function(api, module) {
             Math.min.apply(Math, lefts)
         );
     }
-    
+
     function getTextRangePosition(doc, x, y) {
         var textRange = dom.getBody(doc).createTextRange();
         textRange.moveToPoint(x, y);
@@ -10326,7 +10326,7 @@ rangy.createModule("Position", ["WrappedSelection"], function(api, module) {
 
     function positionFromPoint(doc, x, y, favourPrecedingPosition) {
         var el = doc.elementFromPoint(x, y);
-        
+
         console.log("elementFromPoint is ", el);
 
         var range = api.createRange(doc);
@@ -10396,7 +10396,7 @@ rangy.createModule("Position", ["WrappedSelection"], function(api, module) {
             throw module.createError("createCaretPositionFromPointGetter(): Browser does not provide a recognised method to create a selection from pixel coordinates");
         }
     }
-    
+
     function createRangeFromPoints(startX, startY, endX, endY, doc) {
         doc = dom.getContentDocument(doc, module, "createRangeFromPoints");
         var positionFinder = createCaretPositionFromPointGetter(doc);
@@ -10431,7 +10431,7 @@ rangy.createModule("Position", ["WrappedSelection"], function(api, module) {
         sel.setSingleRange(range);
         return sel;
     }
-    
+
     // Test that <span> elements support getBoundingClientRect
     var span = document.createElementNS("http://www.w3.org/1999/xhtml", "span");
     var elementSupportsGetBoundingClientRect = util.isHostMethod(span, "getBoundingClientRect");
@@ -10717,12 +10717,12 @@ rangy.createModule("Position", ["WrappedSelection"], function(api, module) {
         getStartDocumentPos: createSelectionBoundaryPosGetter(true, true),
         getEndDocumentPos: createSelectionBoundaryPosGetter(false, true)
     });
-    
+
     api.positionFromPoint = function(x, y, doc) {
         doc = dom.getContentDocument(doc, module, "positionFromPoint");
         return createCaretPositionFromPointGetter(doc)(doc, x, y);
     };
-    
+
     api.createRangeFromPoints = createRangeFromPoints;
     api.moveSelectionToPoints = moveSelectionToPoints;
 });
@@ -10734,10 +10734,10 @@ define("rangy-position", ["rangy-core"], (function (global) {
     };
 }(this)));
 
-define('rangy',["rangy-core", 
-        "rangy-highlighter", 
-        "rangy-cssclassapplier", 
-        "rangy-textrange", 
+define('rangy',["rangy-core",
+        "rangy-highlighter",
+        "rangy-cssclassapplier",
+        "rangy-textrange",
         "rangy-position",
 
         //"domReady" //"domReady!" forces wait for DOM doc
@@ -10784,7 +10784,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
 
     var DEFAULT_MO_ACTIVE_CLASS = "mo-active-default";
     var DEFAULT_MO_SUB_SYNC_CLASS = "mo-sub-sync";
-    
+
     //var BACK_COLOR = "#99CCCC";
 
     var _highlightedElementPar = undefined;
@@ -10792,7 +10792,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
     {
         return _highlightedElementPar && par === _highlightedElementPar;
     };
-    
+
     var _highlightedCfiPar = undefined;
     this.isCfiHighlighted = function(par)
     {
@@ -10803,21 +10803,21 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
     var _playbackActiveClass = "";
 
     var _reader = reader;
-    
+
     var USE_RANGY = true && (typeof rangy !== "undefined");
     var _rangyCSS = undefined;
     var _rangyRange = undefined;
-    
+
     var HIGHLIGHT_ID = "MO_SPEAK";
-    
+
     var self = this;
 
     var $userStyle = undefined;
-    
+
     this.reDo = function()
     {
         //this.reset();
-        
+
         if ($userStyle)
         {
             $userStyle.remove();
@@ -10828,7 +10828,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
         var hc = _highlightedCfiPar;
         var c1 = _activeClass;
         var c2 = _playbackActiveClass;
-        
+
         if (_highlightedElementPar)
         {
             this.reset();
@@ -10856,7 +10856,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
             }
             catch (e)
             {
-                
+
             }
         }
 
@@ -10866,9 +10866,9 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
         $userStyle = $("<style type='text/css'> </style>");
 
         $userStyle.append("." + DEFAULT_MO_ACTIVE_CLASS + " {");
-        
+
         var fallbackUserStyle = "background-color: yellow !important; color: black !important; border-radius: 0.4em;";
-        
+
         var style = overrideWithUserStyle; //_reader.userStyles().findStyle("." + DEFAULT_MO_ACTIVE_CLASS);
         if (style)
         {
@@ -10883,7 +10883,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
                 atLeastOne = true;
                 $userStyle.append(prop + ": " + style.declarations[prop] + "; ");
             }
-            
+
             if (!atLeastOne && !hasAuthorStyle)
             {
                 $userStyle.append(fallbackUserStyle);
@@ -10893,19 +10893,19 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
         {
             $userStyle.append(fallbackUserStyle);
         }
-        
+
         $userStyle.append("}");
-        
-        
+
+
         // ---- CFI
         //$userStyle.append(" .highlight {background-color: blue; border: 2x solid green;}"); //.hover-highlight
-        
-        
+
+
         $userStyle.appendTo($head);
 
 //console.debug($userStyle[0].textContent);
     };
-    
+
     this.highlightElement = function(par, activeClass, playbackActiveClass) {
 
         if(!par || par === _highlightedElementPar) {
@@ -10916,13 +10916,13 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
 
         _highlightedElementPar = par;
         _highlightedCfiPar = undefined;
-        
+
         _activeClass = activeClass;
         _playbackActiveClass = playbackActiveClass;
 
         var seq = this.adjustParToSeqSyncGranularity(_highlightedElementPar);
         var element = seq.element;
-        
+
         if (_playbackActiveClass && _playbackActiveClass !== "")
         {
             //console.debug("MO playbackActiveClass: " + _playbackActiveClass);
@@ -10936,7 +10936,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
         var overrideWithUserStyle = _reader.userStyles().findStyle("." + DEFAULT_MO_ACTIVE_CLASS);
 
         ensureUserStyle($hel, hasAuthorStyle, overrideWithUserStyle);
-                
+
         if (overrideWithUserStyle || !hasAuthorStyle)
         {
             //console.debug("MO active NO CLASS: " + _activeClass);
@@ -10945,7 +10945,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
             {
                 $hel.addClass(_activeClass);
             }
-            
+
             $hel.addClass(DEFAULT_MO_ACTIVE_CLASS);
 
             //$(element).css("background", BACK_COLOR);
@@ -10955,12 +10955,12 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
             //console.debug("MO activeClass: " + _activeClass);
             $hel.addClass(_activeClass);
         }
-        
+
         if (this.includeParWhenAdjustingToSeqSyncGranularity || _highlightedElementPar !== seq)
         {
             $(_highlightedElementPar.element).addClass(DEFAULT_MO_SUB_SYNC_CLASS);
         }
-        
+
 // ---- CFI
 //         try
 //         {
@@ -10969,27 +10969,27 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
 //             // if(cfi[0] == "!") {
 //             //     cfi = cfi.substring(1);
 //             // }
-// 
+//
 // //console.log(element);
-//         
+//
 //             var firstTextNode = getFirstTextNode(element);
 //             var txtFirst = firstTextNode.textContent;
 // //console.log(txtFirst);
-// 
+//
 //             var lastTextNode = getLastTextNode(element);
 //             var txtLast = lastTextNode.textContent;
 // //console.log(txtLast);
-//         
+//
 //             var cfi = EPUBcfi.Generator.generateCharOffsetRangeComponent(
-//                     firstTextNode, 
-//                     0, 
-//                     lastTextNode, 
+//                     firstTextNode,
+//                     0,
+//                     lastTextNode,
 //                     txtLast.length,
 //                     ["cfi-marker"],
 //                     [],
 //                     ["MathJax_Message"]
 //                     );
-//             
+//
 //             var id = $hel.data("mediaOverlayData").par.getSmil().spineItemId;
 //             _reader.addHighlight(id, cfi, HIGHLIGHT_ID,
 //             "highlight", //"underline"
@@ -10999,11 +10999,11 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
 //         catch(error)
 //         {
 //             console.error(error);
-//         
+//
 //             removeHighlight();
 //         }
     };
-    
+
     this.highlightCfi = function(par, activeClass, playbackActiveClass) {
 
         if(!par || par === _highlightedCfiPar) {
@@ -11014,7 +11014,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
 
         _highlightedElementPar = undefined;
         _highlightedCfiPar = par;
-        
+
         _activeClass = activeClass;
         _playbackActiveClass = playbackActiveClass;
 
@@ -11046,28 +11046,28 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
                 [],
                 ["MathJax_Message"]);
 //console.log(infoEnd);
-            
+
             _rangyRange.setStartAndEnd(
                 infoStart.textNode[0], infoStart.textOffset,
                 infoEnd.textNode[0], infoEnd.textOffset
             );
-            
+
             if (false && // we use CssClassApplier instead, because surroundContents() has no trivial undoSurroundContents() function (inc. text nodes normalisation, etc.)
                 _rangyRange.canSurroundContents())
             {
                 _rangyRange.MO_createCssClassApplier = false;
-                
+
                 var span = doc.createElementNS("http://www.w3.org/1999/xhtml", 'span');
                 span.id = HIGHLIGHT_ID;
                 span.setAttribute("id", span.id);
                 span.setAttribute("class", clazz + " mo-cfi-highlight");
-            
+
                 _rangyRange.surroundContents(span);
             }
             else
             {
                 _rangyRange.MO_createCssClassApplier = true;
-                
+
                 if (!_rangyCSS || _rangyCSS.cssClass !== clazz)
                 {
                     _rangyCSS = rangy.createCssClassApplier(clazz,
@@ -11101,9 +11101,9 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
             }
         }
     };
-    
+
 // ---- CFI
-//     
+//
 //     function getFirstTextNode(node)
 //     {
 //         if (node.nodeType === Node.TEXT_NODE)
@@ -11111,7 +11111,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
 //             if (node.textContent.trim().length > 0)
 //                 return node;
 //         }
-//         
+//
 //         for (var i = 0; i < node.childNodes.length; i++)
 //         {
 //             var child = node.childNodes[i];
@@ -11121,10 +11121,10 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
 //                 return first;
 //             }
 //         }
-//         
+//
 //         return undefined;
 //     }
-//     
+//
 //     function getLastTextNode(node)
 //     {
 //         if (node.nodeType === Node.TEXT_NODE)
@@ -11132,7 +11132,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
 //             if (node.textContent.trim().length > 0)
 //                 return node;
 //         }
-//         
+//
 //         for (var i = node.childNodes.length-1; i >= 0; i--)
 //         {
 //             var child = node.childNodes[i];
@@ -11142,13 +11142,13 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
 //                 return last;
 //             }
 //         }
-//         
+//
 //         return undefined;
 //     }
-//     
+//
 
     this.reset = function() {
-        
+
         if (_highlightedCfiPar)
         {
             var doc = _highlightedCfiPar.cfi.cfiTextParent.ownerDocument;
@@ -11165,12 +11165,12 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
                     {
                         var txt = toRemove.textContent; // TODO: innerHTML? or better: hasChildNodes loop + detach and re-attach
                         var txtNode = doc.createTextNode(txt);
-                        
+
                         toRemove.parentNode.replaceChild(txtNode, toRemove);
                         txtNode.parentNode.normalize();
                     }
                 }
-        
+
                 //_rangyCSS = undefined;
                 _rangyRange = undefined;
             }
@@ -11179,7 +11179,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
                 try
                 {
                     _reader.removeHighlight(HIGHLIGHT_ID);
-        
+
                     var toRemove = undefined;
                     while ((toRemove = doc.getElementById("start-" + HIGHLIGHT_ID)) !== null)
                     {
@@ -11199,12 +11199,12 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
                     console.error(error);
                 }
             }
-            
+
             _highlightedCfiPar = undefined;
         }
-        
-        
-        
+
+
+
 
         if(_highlightedElementPar) {
 
@@ -11214,7 +11214,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
             {
                 $(_highlightedElementPar.element).removeClass(DEFAULT_MO_SUB_SYNC_CLASS);
             }
-            
+
             if (_playbackActiveClass && _playbackActiveClass !== "")
             {
                 //console.debug("MO RESET playbackActiveClass: " + _playbackActiveClass);
@@ -11243,7 +11243,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
     this.adjustParToSeqSyncGranularity = function(par)
     {
         if (!par) return undefined;
-        
+
         var sync = _reader.viewerSettings().mediaOverlaysSynchronizationGranularity;
         if (sync && sync.length > 0)
         {
@@ -11260,7 +11260,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
                 return seq;
             }
         }
-        
+
         return par;
     };
 };
@@ -11299,7 +11299,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
     var _ttsIsPlaying = false;
     var _currentTTS = undefined;
     var _enableHTMLSpeech = true && typeof window.speechSynthesis !== "undefined" && speechSynthesis != null; // set to false to force "native" platform TTS engine, rather than HTML Speech API
-    
+
     var _SpeechSynthesisUtterance = undefined;
     //var _skipTTSEndEvent = false;
     var TOKENIZE_TTS = false;
@@ -11352,11 +11352,11 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
         // 1) ReadiumSDK.Events.CONTENT_DOCUMENT_LOAD_START
         // (maybe 2-page fixed-layout or reflowable spread == 2 documents == 2x events)
         // MOPLayer.onDocLoad()
-        
+
         // 2) ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED
         // (maybe 2-page fixed-layout or reflowable spread == 2 documents == 2x events)
         //_mediaOverlayDataInjector.attachMediaOverlayData($iframe, spineItem, _viewerSettings);
-        
+
         // 3) ReadiumSDK.Events.PAGINATION_CHANGED (layout finished, notified before rest of app, just once)
         // MOPLayer.onPageChanged()
 
@@ -11367,7 +11367,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
             self.pause();
         }
     };
-    
+
     this.onPageChanged = function(paginationData) {
 
         var wasPlayingAtDocLoadStart = _wasPlayingAtDocLoadStart;
@@ -11393,10 +11393,10 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
 
         var element = undefined;
         var isCfiTextRange = false;
-        
+
         var fakeOpfRoot = "/99!";
         var epubCfiPrefix = "epubcfi";
-        
+
         if (paginationData.elementId || paginationData.initiator == self)
         {
             var spineItems = reader.getLoadedSpineItems();
@@ -11410,13 +11410,13 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                 {
                     continue;
                 }
-                
+
                 if (paginationData.elementId && paginationData.elementId.indexOf(epubCfiPrefix) === 0)
                 {
                     _elementHighlighter.reset(); // ensure clean DOM (no CFI span markers)
-                    
+
                     var partial = paginationData.elementId.substr(epubCfiPrefix.length + 1, paginationData.elementId.length - epubCfiPrefix.length - 2);
-                    
+
                     if (partial.indexOf(fakeOpfRoot) === 0)
                     {
                         partial = partial.substr(fakeOpfRoot.length, partial.length - fakeOpfRoot.length);
@@ -11458,7 +11458,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                 ["cfi-marker", "mo-cfi-highlight"],
                 [],
                 ["MathJax_Message"]);
-                                
+
                             element = ($element && $element.length > 0) ? $element[0] : undefined;
                             if (element)
                             {
@@ -11489,7 +11489,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                         element = ($element && $element.length > 0) ? $element[0] : undefined;
                         //("#" + ReadiumSDK.Helpers.escapeJQuerySelector(paginationData.elementId))
                     }
-                    
+
                     if (element)
                     {
                         /*
@@ -11557,7 +11557,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                 for (var iPar = 0; iPar < moData.pars.length; iPar++)
                 {
                     var p = moData.pars[iPar];
-                    
+
                     if (paginationData.elementId === p.cfi.smilTextSrcCfi)
                     {
                         parToPlay = p;
@@ -11565,7 +11565,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                     }
                 }
             }
-            
+
             playPar(parToPlay);
             return;
         }
@@ -11623,7 +11623,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
             {
                 paginationData.elementIdResolved = element;
             }
-            
+
             self.toggleMediaOverlayRefresh(paginationData);
         }
     };
@@ -11746,7 +11746,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                     $(_currentEmbedded).on("ended", self.onEmbeddedEnd);
 
                     _embeddedIsPlaying = true;
-                    
+
                     // gives the audio player some dispatcher time to raise the onPause event
                     setTimeout(function(){
                         onStatusChanged({isPlaying: true});
@@ -11773,7 +11773,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                     }
                 }
             }
-            
+
             var cfi = _smilIterator.currentPar.cfi;
             if (cfi)
             {
@@ -11782,7 +11782,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                 self.resetBlankPage();
 
                 _elementHighlighter.reset(); // ensure clean DOM (no CFI span markers)
-                
+
                 var doc = cfi.cfiTextParent.ownerDocument;
 
                 var startCFI = "epubcfi(" + cfi.partialStartCfi + ")";
@@ -11925,7 +11925,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
         }
 
         var parFrom = _smilIterator.currentPar;
-        
+
         var audio = _smilIterator.currentPar.audio;
 
         //var TOLERANCE = 0.05;
@@ -11977,7 +11977,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
             //        }
 
 //console.debug("NEXT SMIL ON AUDIO POS");
-        
+
             nextSmil(goNext);
             return;
         }
@@ -11988,7 +11988,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
             self.pause();
             return;
         }
-        
+
         if(_settings.mediaOverlaysSkipSkippables)
         {
             var skip = false;
@@ -12038,7 +12038,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                             return;
                         }
                     }
-                    
+
 //console.debug("ADJUSTED: " + _smilIterator.currentPar.text.srcFragmentId);
                     if (!goNext)
                     {
@@ -12046,7 +12046,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                         if (landed && landed !== _smilIterator.currentPar)
                         {
                             var backup = _smilIterator.currentPar;
-                    
+
                             var innerPar = undefined;
                             do
                             {
@@ -12054,23 +12054,23 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                                 _smilIterator.previous();
                             }
                             while (_smilIterator.currentPar && _smilIterator.currentPar.hasAncestor(landed));
-                        
+
                             if (_smilIterator.currentPar)
                             {
                                 _smilIterator.next();
-                                
+
                                 if (!_smilIterator.currentPar.hasAncestor(landed))
                                 {
                                     console.error("adjustParToSeqSyncGranularity !_smilIterator.currentPar.hasAncestor(landed) ???");
                                 }
-                                //assert 
+                                //assert
                             }
                             else
                             {
 //console.debug("adjustParToSeqSyncGranularity reached begin");
 
                                 _smilIterator.reset();
-                                
+
                                 if (_smilIterator.currentPar !== innerPar)
                                 {
                                     console.error("adjustParToSeqSyncGranularity _smilIterator.currentPar !=== innerPar???");
@@ -12082,14 +12082,14 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                                 console.error("adjustParToSeqSyncGranularity !_smilIterator.currentPar ?????");
                                 _smilIterator.goToPar(backup);
                             }
-                            
+
 //console.debug("ADJUSTED PREV: " + _smilIterator.currentPar.text.srcFragmentId);
                         }
                     }
                 }
             }
         }
-        
+
         if(_audioPlayer.isPlaying()
             && _smilIterator.currentPar.audio.src
             && _smilIterator.currentPar.audio.src == _audioPlayer.currentSmilSrc()
@@ -12284,7 +12284,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
             setTimeout(function(){
                 onStatusChanged({isPlaying: true});
             }, 80);
-            
+
             _ttsIsPlaying = true;
 
             if (TOKENIZE_TTS && element)
@@ -12330,16 +12330,16 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
                     {
                         _SpeechSynthesisUtterance.onend({forceSkipEnd: true, target: _SpeechSynthesisUtterance});
                     }
-                    
+
                     _SpeechSynthesisUtterance.tokenData = undefined;
-                    
+
                     _SpeechSynthesisUtterance.onboundary = undefined;
     //                 _SpeechSynthesisUtterance.onboundary = function(event)
     //                 {
     // console.debug("OLD TTS boundary");
-    //                 
+    //
     //                         event.target.tokenData = undefined;
-    //  
+    //
     //                 };
                 }
 
@@ -12352,7 +12352,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
 //                         event.target.tokenData = undefined;
 //                     }
 //                 };
-                
+
                 _SpeechSynthesisUtterance.onerror = undefined;
 //                 _SpeechSynthesisUtterance.onerror = function(event)
 //                 {
@@ -12372,7 +12372,7 @@ ReadiumSDK.Views.MediaOverlayPlayer = function(reader, onStatusChanged) {
 //            {
 //                _skipTTSEndEvent = true;
 //            }
-            
+
 console.debug("paused: "+window.speechSynthesis.paused);
 console.debug("speaking: "+window.speechSynthesis.speaking);
 console.debug("pending: "+window.speechSynthesis.pending);
@@ -12382,7 +12382,7 @@ console.debug("pending: "+window.speechSynthesis.pending);
 // console.debug("TTS pause before speak");
 //                 window.speechSynthesis.pause();
 //             }
-            
+
             function cancelTTS(first)
             {
                 if (first || window.speechSynthesis.pending)
@@ -12401,7 +12401,7 @@ console.debug("pending: "+window.speechSynthesis.pending);
                 }
             }
             cancelTTS(true);
-            
+
             function updateTTS()
             {
             // setTimeout(function()
@@ -12412,7 +12412,7 @@ console.debug("pending: "+window.speechSynthesis.pending);
                 if (TOKENIZE_TTS && tokenData)
                 {
                     _SpeechSynthesisUtterance.tokenData = tokenData;
-                
+
                     _SpeechSynthesisUtterance.onboundary = function(event)
                     //_SpeechSynthesisUtterance.addEventListener("boundary", function(event)
                     {
@@ -12751,9 +12751,9 @@ console.debug("TTS resume");
 
                     reader.insureElementVisibility(_smilIterator.currentPar.element, self);
                 }
-            
+
                 return;
-            
+
             } else if (_smilIterator.currentPar.cfi) {
 
                 if (!_elementHighlighter.isCfiHighlighted(_smilIterator.currentPar))
@@ -12762,18 +12762,18 @@ console.debug("TTS resume");
 
                     reader.insureElementVisibility(_smilIterator.currentPar.cfi.cfiTextParent, self);
                 }
-                
+
                 return;
             }
         }
-        
+
         // body (not FRAG ID)
         if (_smilIterator.currentPar.element) {
             return;
         }
-        
+
         //else: single SMIL per multiple XHTML? ==> open new spine item
-        
+
         /*
         var textRelativeRef = ReadiumSDK.Helpers.ResolveContentRef(_smilIterator.currentPar.text.srcFile, _smilIterator.smil.href);
 console.debug("textRelativeRef: " + textRelativeRef);
@@ -12795,7 +12795,7 @@ console.debug("textAbsoluteRef: " + textAbsoluteRef);
     }
 
     this.escape = function() {
-        
+
         if(!_smilIterator || !_smilIterator.currentPar) {
 
             this.toggleMediaOverlay();
@@ -12854,9 +12854,9 @@ console.debug("textAbsoluteRef: " + textAbsoluteRef);
                 var findFirstPar = function(smilNode)
                 {
                     if (smilNode.nodeType && smilNode.nodeType === "par") return smilNode;
-                    
+
                     if (!smilNode.children || smilNode.children.length <= 0) return undefined;
-                    
+
                     for (var i = 0; i < smilNode.children.length; i++)
                     {
                         var child = smilNode.children[i];
@@ -13022,7 +13022,7 @@ console.debug("textAbsoluteRef: " + textAbsoluteRef);
 
         onAudioPositionChanged(position, 6);
         // setTimeout(function(){
-        //     
+        //
         // }, 1);
 
         //self.play();
@@ -13146,7 +13146,7 @@ console.debug("textAbsoluteRef: " + textAbsoluteRef);
             {
                 console.error("[WARN] id did not resolve to element?");
             }
-            
+
             for(var i = (rtl ? (spineItems.length - 1) : 0); (rtl && i >=0) || (!rtl && i < spineItems.length); i += (rtl ? -1: 1))
             {
                 var spineItem = spineItems[i];
@@ -13155,7 +13155,7 @@ console.debug("textAbsoluteRef: " + textAbsoluteRef);
                     console.error("spineItems[i] is undefined??");
                     continue;
                 }
-            
+
                 if (paginationData && paginationData.spineItem && paginationData.spineItem != spineItem)
                 {
                     continue;
@@ -13173,7 +13173,7 @@ console.debug("textAbsoluteRef: " + textAbsoluteRef);
                     {
                         // openPages are sorted by spineItem index, so the smallest index on display is the one we need to play (page on the left in LTR, or page on the right in RTL progression)
                         var index = 0; // paginationData.paginationInfo.pageProgressionDirection === "ltr" ? 0 : paginationData.paginationInfo.openPages.length - 1;
-                    
+
                         if (paginationData.paginationInfo.openPages[index] && paginationData.paginationInfo.openPages[index].idref && paginationData.paginationInfo.openPages[index].idref === spineItem.idref)
                         {
                             var $element = reader.getElement(spineItem, "body");
@@ -13215,7 +13215,7 @@ console.debug("textAbsoluteRef: " + textAbsoluteRef);
                 for (var i = 0; i < elements.length; i++)
                 {
                     if (element === elements[i]) foundMe = true;
-                    
+
                     if (foundMe)
                     {
                         var d = $(elements[i]).data("mediaOverlayData");
@@ -13267,15 +13267,15 @@ console.debug("textAbsoluteRef: " + textAbsoluteRef);
         {
             _smilIterator.reset();
         }
-        
+
         _smilIterator.goToPar(zPar);
-        
+
         if (!_smilIterator.currentPar && id)
         {
             _smilIterator.reset();
             _smilIterator.findTextId(id);
         }
-        
+
         if (!_smilIterator.currentPar)
         {
             self.reset();
@@ -13398,7 +13398,7 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
    *
    * http://pegjs.majda.cz/
    */
-  
+
   function quote(s) {
     /*
      * ECMA-262, 5th ed., 7.8.4: All characters may appear literally in a
@@ -13421,7 +13421,7 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
       .replace(/[\x00-\x07\x0B\x0E-\x1F\x80-\uFFFF]/g, escape)
       + '"';
   }
-  
+
   var result = {
     /*
      * Parses the input with a generated parser. If the parsing is successfull,
@@ -13457,7 +13457,7 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         "equal": parse_equal,
         "character": parse_character
       };
-      
+
       if (startRule !== undefined) {
         if (parseFunctions[startRule] === undefined) {
           throw new Error("Invalid rule name: " + quote(startRule) + ".");
@@ -13465,28 +13465,28 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
       } else {
         startRule = "fragment";
       }
-      
+
       var pos = 0;
       var reportFailures = 0;
       var rightmostFailuresPos = 0;
       var rightmostFailuresExpected = [];
-      
+
       function padLeft(input, padding, length) {
         var result = input;
-        
+
         var padLength = length - input.length;
         for (var i = 0; i < padLength; i++) {
           result = padding + result;
         }
-        
+
         return result;
       }
-      
+
       function escape(ch) {
         var charCode = ch.charCodeAt(0);
         var escapeChar;
         var length;
-        
+
         if (charCode <= 0xFF) {
           escapeChar = 'x';
           length = 2;
@@ -13494,27 +13494,27 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           escapeChar = 'u';
           length = 4;
         }
-        
+
         return '\\' + escapeChar + padLeft(charCode.toString(16).toUpperCase(), '0', length);
       }
-      
+
       function matchFailed(failure) {
         if (pos < rightmostFailuresPos) {
           return;
         }
-        
+
         if (pos > rightmostFailuresPos) {
           rightmostFailuresPos = pos;
           rightmostFailuresExpected = [];
         }
-        
+
         rightmostFailuresExpected.push(failure);
       }
-      
+
       function parse_fragment() {
         var result0, result1, result2;
         var pos0, pos1;
-        
+
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 8) === "epubcfi(") {
@@ -13556,8 +13556,8 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, fragmentVal) { 
-                
+          result0 = (function(offset, fragmentVal) {
+
                 return { type:"CFIAST", cfiString:fragmentVal };
             })(pos0, result0[1]);
         }
@@ -13566,11 +13566,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_range() {
         var result0, result1, result2, result3, result4, result5;
         var pos0, pos1;
-        
+
         pos0 = pos;
         pos1 = pos;
         result0 = parse_indexStep();
@@ -13628,7 +13628,7 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         if (result0 !== null) {
           result0 = (function(offset, stepVal, localPathVal, rangeLocalPath1Val, rangeLocalPath2Val) {
-        
+
                 return { type:"range", path:stepVal, localPath:localPathVal, range1:rangeLocalPath1Val, range2:rangeLocalPath2Val };
           })(pos0, result0[0], result0[1], result0[3], result0[5]);
         }
@@ -13637,11 +13637,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_path() {
         var result0, result1;
         var pos0, pos1;
-        
+
         pos0 = pos;
         pos1 = pos;
         result0 = parse_indexStep();
@@ -13658,9 +13658,9 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, stepVal, localPathVal) { 
-        
-                return { type:"path", path:stepVal, localPath:localPathVal }; 
+          result0 = (function(offset, stepVal, localPathVal) {
+
+                return { type:"path", path:stepVal, localPath:localPathVal };
             })(pos0, result0[0], result0[1]);
         }
         if (result0 === null) {
@@ -13668,11 +13668,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_local_path() {
         var result0, result1;
         var pos0, pos1;
-        
+
         pos0 = pos;
         pos1 = pos;
         result1 = parse_indexStep();
@@ -13705,9 +13705,9 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, localPathStepVal, termStepVal) { 
-        
-                return { steps:localPathStepVal, termStep:termStepVal }; 
+          result0 = (function(offset, localPathStepVal, termStepVal) {
+
+                return { steps:localPathStepVal, termStep:termStepVal };
             })(pos0, result0[0], result0[1]);
         }
         if (result0 === null) {
@@ -13715,11 +13715,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_indexStep() {
         var result0, result1, result2, result3, result4;
         var pos0, pos1, pos2;
-        
+
         pos0 = pos;
         pos1 = pos;
         if (input.charCodeAt(pos) === 47) {
@@ -13786,8 +13786,8 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, stepLengthVal, assertVal) { 
-        
+          result0 = (function(offset, stepLengthVal, assertVal) {
+
                 return { type:"indexStep", stepLength:stepLengthVal, idAssertion:assertVal[1] };
             })(pos0, result0[1], result0[2]);
         }
@@ -13796,11 +13796,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_indirectionStep() {
         var result0, result1, result2, result3, result4;
         var pos0, pos1, pos2;
-        
+
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 2) === "!/") {
@@ -13867,8 +13867,8 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, stepLengthVal, assertVal) { 
-        
+          result0 = (function(offset, stepLengthVal, assertVal) {
+
                 return { type:"indirectionStep", stepLength:stepLengthVal, idAssertion:assertVal[1] };
             })(pos0, result0[1], result0[2]);
         }
@@ -13877,11 +13877,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_terminus() {
         var result0, result1, result2, result3, result4;
         var pos0, pos1, pos2;
-        
+
         pos0 = pos;
         pos1 = pos;
         if (input.charCodeAt(pos) === 58) {
@@ -13948,8 +13948,8 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, textOffsetValue, textLocAssertVal) { 
-        
+          result0 = (function(offset, textOffsetValue, textLocAssertVal) {
+
                 return { type:"textTerminus", offsetValue:textOffsetValue, textAssertion:textLocAssertVal[1] };
             })(pos0, result0[1], result0[2]);
         }
@@ -13958,17 +13958,17 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_idAssertion() {
         var result0;
         var pos0;
-        
+
         pos0 = pos;
         result0 = parse_value();
         if (result0 !== null) {
-          result0 = (function(offset, idVal) { 
-        
-                return idVal; 
+          result0 = (function(offset, idVal) {
+
+                return idVal;
             })(pos0, result0);
         }
         if (result0 === null) {
@@ -13976,11 +13976,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_textLocationAssertion() {
         var result0, result1;
         var pos0, pos1;
-        
+
         pos0 = pos;
         pos1 = pos;
         result0 = parse_csv();
@@ -13999,9 +13999,9 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, csvVal, paramVal) { 
-        
-                return { type:"textLocationAssertion", csv:csvVal, parameter:paramVal }; 
+          result0 = (function(offset, csvVal, paramVal) {
+
+                return { type:"textLocationAssertion", csv:csvVal, parameter:paramVal };
             })(pos0, result0[0], result0[1]);
         }
         if (result0 === null) {
@@ -14009,11 +14009,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_parameter() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
+
         pos0 = pos;
         pos1 = pos;
         if (input.charCodeAt(pos) === 59) {
@@ -14058,9 +14058,9 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, paramLHSVal, paramRHSVal) { 
-        
-                return { type:"parameter", LHSValue:paramLHSVal, RHSValue:paramRHSVal }; 
+          result0 = (function(offset, paramLHSVal, paramRHSVal) {
+
+                return { type:"parameter", LHSValue:paramLHSVal, RHSValue:paramRHSVal };
             })(pos0, result0[1], result0[3]);
         }
         if (result0 === null) {
@@ -14068,11 +14068,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_csv() {
         var result0, result1, result2;
         var pos0, pos1;
-        
+
         pos0 = pos;
         pos1 = pos;
         result0 = parse_value();
@@ -14105,9 +14105,9 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, preAssertionVal, postAssertionVal) { 
-        
-                return { type:"csv", preAssertion:preAssertionVal, postAssertion:postAssertionVal }; 
+          result0 = (function(offset, preAssertionVal, postAssertionVal) {
+
+                return { type:"csv", preAssertion:preAssertionVal, postAssertion:postAssertionVal };
             })(pos0, result0[0], result0[2]);
         }
         if (result0 === null) {
@@ -14115,11 +14115,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_valueNoSpace() {
         var result0, result1;
         var pos0;
-        
+
         pos0 = pos;
         result1 = parse_escapedSpecialChars();
         if (result1 === null) {
@@ -14138,9 +14138,9 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           result0 = null;
         }
         if (result0 !== null) {
-          result0 = (function(offset, stringVal) { 
-        
-                return stringVal.join(''); 
+          result0 = (function(offset, stringVal) {
+
+                return stringVal.join('');
             })(pos0, result0);
         }
         if (result0 === null) {
@@ -14148,11 +14148,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_value() {
         var result0, result1;
         var pos0;
-        
+
         pos0 = pos;
         result1 = parse_escapedSpecialChars();
         if (result1 === null) {
@@ -14177,9 +14177,9 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           result0 = null;
         }
         if (result0 !== null) {
-          result0 = (function(offset, stringVal) { 
-        
-                return stringVal.join(''); 
+          result0 = (function(offset, stringVal) {
+
+                return stringVal.join('');
             })(pos0, result0);
         }
         if (result0 === null) {
@@ -14187,11 +14187,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_escapedSpecialChars() {
         var result0, result1;
         var pos0, pos1;
-        
+
         pos0 = pos;
         pos1 = pos;
         result0 = parse_circumflex();
@@ -14288,9 +14288,9 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           }
         }
         if (result0 !== null) {
-          result0 = (function(offset, escSpecCharVal) { 
-                
-                return escSpecCharVal[1]; 
+          result0 = (function(offset, escSpecCharVal) {
+
+                return escSpecCharVal[1];
             })(pos0, result0);
         }
         if (result0 === null) {
@@ -14298,11 +14298,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_number() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
+
         pos0 = pos;
         pos1 = pos;
         pos2 = pos;
@@ -14421,9 +14421,9 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset, intPartVal, fracPartVal) { 
-        
-                return intPartVal.join('') + "." + fracPartVal.join(''); 
+          result0 = (function(offset, intPartVal, fracPartVal) {
+
+                return intPartVal.join('') + "." + fracPartVal.join('');
             })(pos0, result0[0], result0[2]);
         }
         if (result0 === null) {
@@ -14431,11 +14431,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_integer() {
         var result0, result1, result2;
         var pos0, pos1;
-        
+
         pos0 = pos;
         if (input.charCodeAt(pos) === 48) {
           result0 = "0";
@@ -14492,12 +14492,12 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           }
         }
         if (result0 !== null) {
-          result0 = (function(offset, integerVal) { 
-        
-                if (integerVal === "0") { 
+          result0 = (function(offset, integerVal) {
+
+                if (integerVal === "0") {
                   return "0";
-                } 
-                else { 
+                }
+                else {
                   return integerVal[0].concat(integerVal[1].join(''));
                 }
             })(pos0, result0);
@@ -14507,11 +14507,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_space() {
         var result0;
         var pos0;
-        
+
         pos0 = pos;
         if (input.charCodeAt(pos) === 32) {
           result0 = " ";
@@ -14530,11 +14530,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_circumflex() {
         var result0;
         var pos0;
-        
+
         pos0 = pos;
         if (input.charCodeAt(pos) === 94) {
           result0 = "^";
@@ -14553,11 +14553,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_doubleQuote() {
         var result0;
         var pos0;
-        
+
         pos0 = pos;
         if (input.charCodeAt(pos) === 34) {
           result0 = "\"";
@@ -14576,11 +14576,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_squareBracket() {
         var result0;
         var pos0;
-        
+
         pos0 = pos;
         if (input.charCodeAt(pos) === 91) {
           result0 = "[";
@@ -14610,11 +14610,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_parentheses() {
         var result0;
         var pos0;
-        
+
         pos0 = pos;
         if (input.charCodeAt(pos) === 40) {
           result0 = "(";
@@ -14644,11 +14644,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_comma() {
         var result0;
         var pos0;
-        
+
         pos0 = pos;
         if (input.charCodeAt(pos) === 44) {
           result0 = ",";
@@ -14667,11 +14667,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_semicolon() {
         var result0;
         var pos0;
-        
+
         pos0 = pos;
         if (input.charCodeAt(pos) === 59) {
           result0 = ";";
@@ -14690,11 +14690,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_equal() {
         var result0;
         var pos0;
-        
+
         pos0 = pos;
         if (input.charCodeAt(pos) === 61) {
           result0 = "=";
@@ -14713,11 +14713,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
+
       function parse_character() {
         var result0;
         var pos0;
-        
+
         pos0 = pos;
         if (/^[a-z]/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
@@ -14791,11 +14791,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return result0;
       }
-      
-      
+
+
       function cleanupExpected(expected) {
         expected.sort();
-        
+
         var lastExpected = null;
         var cleanExpected = [];
         for (var i = 0; i < expected.length; i++) {
@@ -14806,7 +14806,7 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         }
         return cleanExpected;
       }
-      
+
       function computeErrorPosition() {
         /*
          * The first idea was to use |String.split| to break the input up to the
@@ -14814,11 +14814,11 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
          * there. However IE's |split| implementation is so broken that it was
          * enough to prevent it.
          */
-        
+
         var line = 1;
         var column = 1;
         var seenCR = false;
-        
+
         for (var i = 0; i < Math.max(pos, rightmostFailuresPos); i++) {
           var ch = input.charAt(i);
           if (ch === "\n") {
@@ -14834,13 +14834,13 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
             seenCR = false;
           }
         }
-        
+
         return { line: line, column: column };
       }
-      
-      
+
+
       var result = parseFunctions[startRule]();
-      
+
       /*
        * The parser is now in one of the following three states:
        *
@@ -14869,7 +14869,7 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
         var offset = Math.max(pos, rightmostFailuresPos);
         var found = offset < input.length ? input.charAt(offset) : null;
         var errorPosition = computeErrorPosition();
-        
+
         throw new this.SyntaxError(
           cleanupExpected(rightmostFailuresExpected),
           found,
@@ -14878,20 +14878,20 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
           errorPosition.column
         );
       }
-      
+
       return result;
     },
-    
+
     /* Returns the parser source code. */
     toSource: function() { return this._source; }
   };
-  
+
   /* Thrown when a parser encounters a syntax error. */
-  
+
   result.SyntaxError = function(expected, found, offset, line, column) {
     function buildMessage(expected, found) {
       var expectedHumanized, foundHumanized;
-      
+
       switch (expected.length) {
         case 0:
           expectedHumanized = "end of input";
@@ -14904,12 +14904,12 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
             + " or "
             + expected[expected.length - 1];
       }
-      
+
       foundHumanized = found ? quote(found) : "end of input";
-      
+
       return "Expected " + expectedHumanized + " but " + foundHumanized + " found.";
     }
-    
+
     this.name = "SyntaxError";
     this.expected = expected;
     this.found = found;
@@ -14918,15 +14918,15 @@ define("pageOpenRequest", ["readiumSDK"], (function (global) {
     this.line = line;
     this.column = column;
   };
-  
+
   result.SyntaxError.prototype = Error.prototype;
-  
+
   return result;
 })();
 
-    // Description: This model contains the implementation for "instructions" included in the EPUB CFI domain specific language (DSL). 
-//   Lexing and parsing a CFI produces a set of executable instructions for processing a CFI (represented in the AST). 
-//   This object contains a set of functions that implement each of the executable instructions in the AST. 
+    // Description: This model contains the implementation for "instructions" included in the EPUB CFI domain specific language (DSL).
+//   Lexing and parsing a CFI produces a set of executable instructions for processing a CFI (represented in the AST).
+//   This object contains a set of functions that implement each of the executable instructions in the AST.
 
 EPUBcfi.CFIInstructions = {
 
@@ -14936,7 +14936,7 @@ EPUBcfi.CFIInstructions = {
 
 	// Description: Follows a step
 	// Rationale: The use of children() is important here, as this jQuery method returns a tree of xml nodes, EXCLUDING
-	//   CDATA and text nodes. When we index into the set of child elements, we are assuming that text nodes have been 
+	//   CDATA and text nodes. When we index into the set of child elements, we are assuming that text nodes have been
 	//   excluded.
 	// REFACTORING CANDIDATE: This should be called "followIndexStep"
 	getNextNode : function (CFIStepValue, $currNode, classBlacklist, elementBlacklist, idBlacklist) {
@@ -14955,15 +14955,15 @@ EPUBcfi.CFIInstructions = {
 		return $targetNode;
 	},
 
-	// Description: This instruction executes an indirection step, where a resource is retrieved using a 
+	// Description: This instruction executes an indirection step, where a resource is retrieved using a
 	//   link contained on a attribute of the target element. The attribute that contains the link differs
-	//   depending on the target. 
-	// Note: Iframe indirection will (should) fail if the iframe is not from the same domain as its containing script due to 
+	//   depending on the target.
+	// Note: Iframe indirection will (should) fail if the iframe is not from the same domain as its containing script due to
 	//   the cross origin security policy
 	followIndirectionStep : function (CFIStepValue, $currNode, classBlacklist, elementBlacklist, idBlacklist) {
 
 		var that = this;
-		var $contentDocument; 
+		var $contentDocument;
 		var $blacklistExcluded;
 		var $startElement;
 		var $targetNode;
@@ -14989,7 +14989,7 @@ EPUBcfi.CFIInstructions = {
 			$targetNode = this.getNextNode(CFIStepValue, $startElement, classBlacklist, elementBlacklist, idBlacklist);
 
 			// Return that shit!
-			return $targetNode; 
+			return $targetNode;
 		}
 
 		// TODO: Other types of indirection
@@ -15008,7 +15008,7 @@ EPUBcfi.CFIInstructions = {
 		if ($currNode === undefined) {
 
 			throw EPUBcfi.NodeTypeError($currNode, "expected a terminating node, or node list");
-		} 
+		}
 		else if ($currNode.length === 0) {
 
 			throw EPUBcfi.TerminusError("Text", "Text offset:" + textOffset, "no nodes found for termination condition");
@@ -15018,8 +15018,8 @@ EPUBcfi.CFIInstructions = {
 		return $injectedElement;
 	},
 
-	// Description: Checks that the id assertion for the node target matches that on 
-	//   the found node. 
+	// Description: Checks that the id assertion for the node target matches that on
+	//   the found node.
 	targetIdMatchesIdAssertion : function ($foundNode, idAssertion) {
 
 		if ($foundNode.attr("id") === idAssertion) {
@@ -15066,8 +15066,8 @@ EPUBcfi.CFIInstructions = {
 		return (targetIndex > numChildElements - 1) ? true : false;
 	},
 
-	// Rationale: In order to inject an element into a specific position, access to the parent object 
-	//   is required. This is obtained with the jquery parent() method. An alternative would be to 
+	// Rationale: In order to inject an element into a specific position, access to the parent object
+	//   is required. This is obtained with the jquery parent() method. An alternative would be to
 	//   pass in the parent with a filtered list containing only children that are part of the target text node.
     injectCFIMarkerIntoText : function ($textNodeList, textOffset, elementToInject) {
 
@@ -15089,7 +15089,7 @@ EPUBcfi.CFIInstructions = {
                 if (currNodeMaxIndex > textOffset) {
 
                     // This node is going to be split and the components re-inserted
-                    originalText = $textNodeList[nodeNum].nodeValue;	
+                    originalText = $textNodeList[nodeNum].nodeValue;
 
                     // Before part
                     $textNodeList[nodeNum].nodeValue = originalText.slice(0, nodeOffset);
@@ -15115,24 +15115,24 @@ EPUBcfi.CFIInstructions = {
 
         throw EPUBcfi.TerminusError("Text", "Text offset:" + textOffset, "The offset exceeded the length of the text");
     },
-	
-	
-	
-	
-	
-	// Rationale: In order to inject an element into a specific position, access to the parent object 
-	//   is required. This is obtained with the jquery parent() method. An alternative would be to 
+
+
+
+
+
+	// Rationale: In order to inject an element into a specific position, access to the parent object
+	//   is required. This is obtained with the jquery parent() method. An alternative would be to
 	//   pass in the parent with a filtered list containing only children that are part of the target text node.
 
 	// Description: This method finds a target text node and then injects an element into the appropriate node
-	// Rationale: The possibility that cfi marker elements have been injected into a text node at some point previous to 
+	// Rationale: The possibility that cfi marker elements have been injected into a text node at some point previous to
 	//   this method being called (and thus splitting the original text node into two separate text nodes) necessitates that
 	//   the set of nodes that compromised the original target text node are inferred and returned.
-	// Notes: Passed a current node. This node should have a set of elements under it. This will include at least one text node, 
-	//   element nodes (maybe), or possibly a mix. 
+	// Notes: Passed a current node. This node should have a set of elements under it. This will include at least one text node,
+	//   element nodes (maybe), or possibly a mix.
 	// REFACTORING CANDIDATE: This method is pretty long (and confusing). Worth investigating to see if it can be refactored into something clearer.
 	inferTargetTextNode : function (CFIStepValue, $currNode, classBlacklist, elementBlacklist, idBlacklist) {
-		
+
 		var $elementsWithoutMarkers;
 		var currLogicalTextNodeIndex;
 		var targetLogicalTextNodeIndex;
@@ -15140,8 +15140,8 @@ EPUBcfi.CFIInstructions = {
 		var $targetTextNodeList;
 		var prevNodeWasTextNode;
 
-		// Remove any cfi marker elements from the set of elements. 
-		// Rationale: A filtering function is used, as simply using a class selector with jquery appears to 
+		// Remove any cfi marker elements from the set of elements.
+		// Rationale: A filtering function is used, as simply using a class selector with jquery appears to
 		//   result in behaviour where text nodes are also filtered out, along with the class element being filtered.
 		$elementsWithoutMarkers = this.applyBlacklist($currNode.contents(), classBlacklist, elementBlacklist, idBlacklist);
 
@@ -15162,10 +15162,10 @@ EPUBcfi.CFIInstructions = {
 						return true;
 					}
 					// Rationale: The logical text node position is only incremented once a group of text nodes (a single logical
-					//   text node) has been passed by the loop. 
+					//   text node) has been passed by the loop.
 					else if (prevNodeWasTextNode && (this.nodeType !== Node.TEXT_NODE)) {
 						currLogicalTextNodeIndex++;
-						prevNodeWasTextNode = false;			
+						prevNodeWasTextNode = false;
 						return false;
 					}
 				}
@@ -15185,7 +15185,7 @@ EPUBcfi.CFIInstructions = {
 			}
 		);
 
-		// The filtering above should have counted the number of "logical" text nodes; this can be used to 
+		// The filtering above should have counted the number of "logical" text nodes; this can be used to
 		// detect out of range errors
 		if ($targetTextNodeList.length === 0) {
 			throw EPUBcfi.OutOfRangeError(logicalTargetTextNodeIndex, currLogicalTextNodeIndex, "Index out of range");
@@ -15220,7 +15220,7 @@ EPUBcfi.CFIInstructions = {
                 }
 
                 if (elementBlacklist) {
-                	
+
 	                // For each type of element
 	                $.each(elementBlacklist, function (index, value) {
 
@@ -15234,7 +15234,7 @@ EPUBcfi.CFIInstructions = {
 				}
 
 				if (idBlacklist) {
-                	
+
 	                // For each type of element
 	                $.each(idBlacklist, function (index, value) {
 
@@ -15262,15 +15262,15 @@ EPUBcfi.CFIInstructions = {
 //   represent the position or area in the EPUB referenced by a CFI.
 // Rationale: The AST is a clean and readable expression of the step-terminus structure of a CFI. Although building an interpreter adds to the
 //   CFI infrastructure, it provides a number of benefits. First, it emphasizes a clear separation of concerns between lexing/parsing a
-//   CFI, which involves some complexity related to escaped and special characters, and the execution of the underlying set of steps 
+//   CFI, which involves some complexity related to escaped and special characters, and the execution of the underlying set of steps
 //   represented by the CFI. Second, it will be easier to extend the interpreter to account for new/altered CFI steps (say for references
-//   to vector objects or multiple CFIs) than if lexing, parsing and interpretation were all handled in a single step. Finally, Readium's objective is 
-//   to demonstrate implementation of the EPUB 3.0 spec. An implementation with a strong separation of concerns that conforms to 
-//   well-understood patterns for DSL processing should be easier to communicate, analyze and understand. 
-// REFACTORING CANDIDATE: node type errors shouldn't really be possible if the CFI syntax is correct and the parser is error free. 
-//   Might want to make the script die in those instances, once the grammar and interpreter are more stable. 
-// REFACTORING CANDIDATE: The use of the 'nodeType' property is confusing as this is a DOM node property and the two are unrelated. 
-//   Whoops. There shouldn't be any interference, however, I think this should be changed. 
+//   to vector objects or multiple CFIs) than if lexing, parsing and interpretation were all handled in a single step. Finally, Readium's objective is
+//   to demonstrate implementation of the EPUB 3.0 spec. An implementation with a strong separation of concerns that conforms to
+//   well-understood patterns for DSL processing should be easier to communicate, analyze and understand.
+// REFACTORING CANDIDATE: node type errors shouldn't really be possible if the CFI syntax is correct and the parser is error free.
+//   Might want to make the script die in those instances, once the grammar and interpreter are more stable.
+// REFACTORING CANDIDATE: The use of the 'nodeType' property is confusing as this is a DOM node property and the two are unrelated.
+//   Whoops. There shouldn't be any interference, however, I think this should be changed.
 
 EPUBcfi.Interpreter = {
 
@@ -15278,18 +15278,18 @@ EPUBcfi.Interpreter = {
     //  "PUBLIC" METHODS (THE API)                                                          //
     // ------------------------------------------------------------------------------------ //
 
-    // Description: Find the content document referenced by the spine item. This should be the spine item 
+    // Description: Find the content document referenced by the spine item. This should be the spine item
     //   referenced by the first indirection step in the CFI.
-    // Rationale: This method is a part of the API so that the reading system can "interact" the content document 
-    //   pointed to by a CFI. If this is not a separate step, the processing of the CFI must be tightly coupled with 
-    //   the reading system, as it stands now. 
+    // Rationale: This method is a part of the API so that the reading system can "interact" the content document
+    //   pointed to by a CFI. If this is not a separate step, the processing of the CFI must be tightly coupled with
+    //   the reading system, as it stands now.
     getContentDocHref : function (CFI, packageDocument, classBlacklist, elementBlacklist, idBlacklist) {
 
         var $packageDocument = $(packageDocument);
         var decodedCFI = decodeURI(CFI);
         var CFIAST = EPUBcfi.Parser.parse(decodedCFI);
 
-        if (!CFIAST || CFIAST.type !== "CFIAST") { 
+        if (!CFIAST || CFIAST.type !== "CFIAST") {
             throw EPUBcfi.NodeTypeError(CFIAST, "expected CFI AST root node");
         }
 
@@ -15315,7 +15315,7 @@ EPUBcfi.Interpreter = {
         var indirectionStepNum;
         var $currElement;
 
-        // Rationale: Since the correct content document for this CFI is already being passed, we can skip to the beginning 
+        // Rationale: Since the correct content document for this CFI is already being passed, we can skip to the beginning
         //   of the indirection step that referenced the content document.
         // Note: This assumes that indirection steps and index steps conform to an interface: an object with stepLength, idAssertion
         indirectionStepNum = this.getFirstIndirectionStepNum(CFIAST);
@@ -15343,7 +15343,7 @@ EPUBcfi.Interpreter = {
         var $range1TargetElement;
         var $range2TargetElement;
 
-        // Rationale: Since the correct content document for this CFI is already being passed, we can skip to the beginning 
+        // Rationale: Since the correct content document for this CFI is already being passed, we can skip to the beginning
         //   of the indirection step that referenced the content document.
         // Note: This assumes that indirection steps and index steps conform to an interface: an object with stepLength, idAssertion
         indirectionStepNum = this.getFirstIndirectionStepNum(CFIAST);
@@ -15368,7 +15368,7 @@ EPUBcfi.Interpreter = {
         };
     },
 
-    // Description: This method will return the element or node (say, a text node) that is the final target of the 
+    // Description: This method will return the element or node (say, a text node) that is the final target of the
     //   the CFI.
     getTargetElement : function (CFI, contentDocument, classBlacklist, elementBlacklist, idBlacklist) {
 
@@ -15377,8 +15377,8 @@ EPUBcfi.Interpreter = {
         var indirectionNode;
         var indirectionStepNum;
         var $currElement;
-        
-        // Rationale: Since the correct content document for this CFI is already being passed, we can skip to the beginning 
+
+        // Rationale: Since the correct content document for this CFI is already being passed, we can skip to the beginning
         //   of the indirection step that referenced the content document.
         // Note: This assumes that indirection steps and index steps conform to an interface: an object with stepLength, idAssertion
         indirectionStepNum = this.getFirstIndirectionStepNum(CFIAST);
@@ -15401,8 +15401,8 @@ EPUBcfi.Interpreter = {
         var $currElement;
         var $range1TargetElement;
         var $range2TargetElement;
-        
-        // Rationale: Since the correct content document for this CFI is already being passed, we can skip to the beginning 
+
+        // Rationale: Since the correct content document for this CFI is already being passed, we can skip to the beginning
         //   of the indirection step that referenced the content document.
         // Note: This assumes that indirection steps and index steps conform to an interface: an object with stepLength, idAssertion
         indirectionStepNum = this.getFirstIndirectionStepNum(CFIAST);
@@ -15425,13 +15425,13 @@ EPUBcfi.Interpreter = {
         };
     },
 
-    // Description: This method allows a "partial" CFI to be used to reference a target in a content document, without a 
-    //   package document CFI component. 
+    // Description: This method allows a "partial" CFI to be used to reference a target in a content document, without a
+    //   package document CFI component.
     // Arguments: {
-    //     contentDocumentCFI : This is a partial CFI that represents a path in a content document only. This partial must be 
+    //     contentDocumentCFI : This is a partial CFI that represents a path in a content document only. This partial must be
     //        syntactically valid, even though it references a path starting at the top of a content document (which is a CFI that
     //        that has no defined meaning in the spec.)
-    //     contentDocument : A DOM representation of the content document to which the partial CFI refers. 
+    //     contentDocument : A DOM representation of the content document to which the partial CFI refers.
     // }
     // Rationale: This method exists to meet the requirements of the Readium-SDK and should be used with care
     getTargetElementWithPartialCFI : function (contentDocumentCFI, contentDocument, classBlacklist, elementBlacklist, idBlacklist) {
@@ -15439,24 +15439,24 @@ EPUBcfi.Interpreter = {
         var decodedCFI = decodeURI(contentDocumentCFI);
         var CFIAST = EPUBcfi.Parser.parse(decodedCFI);
         var indirectionNode;
-        
-        // Interpret the path node 
+
+        // Interpret the path node
         var $currElement = this.interpretIndexStepNode(CFIAST.cfiString.path, $("html", contentDocument), classBlacklist, elementBlacklist, idBlacklist);
 
         // Interpret the rest of the steps
         $currElement = this.interpretLocalPath(CFIAST.cfiString.localPath, 0, $currElement, classBlacklist, elementBlacklist, idBlacklist);
 
         // Return the element at the end of the CFI
-        return $currElement;        
+        return $currElement;
     },
 
-    // Description: This method allows a "partial" CFI to be used, with a content document, to return the text node and offset 
+    // Description: This method allows a "partial" CFI to be used, with a content document, to return the text node and offset
     //    referenced by the partial CFI.
     // Arguments: {
-    //     contentDocumentCFI : This is a partial CFI that represents a path in a content document only. This partial must be 
+    //     contentDocumentCFI : This is a partial CFI that represents a path in a content document only. This partial must be
     //        syntactically valid, even though it references a path starting at the top of a content document (which is a CFI that
     //        that has no defined meaning in the spec.)
-    //     contentDocument : A DOM representation of the content document to which the partial CFI refers. 
+    //     contentDocument : A DOM representation of the content document to which the partial CFI refers.
     // }
     // Rationale: This method exists to meet the requirements of the Readium-SDK and should be used with care
     getTextTerminusInfoWithPartialCFI : function (contentDocumentCFI, contentDocument, classBlacklist, elementBlacklist, idBlacklist) {
@@ -15465,8 +15465,8 @@ EPUBcfi.Interpreter = {
         var CFIAST = EPUBcfi.Parser.parse(decodedCFI);
         var indirectionNode;
         var textOffset;
-        
-        // Interpret the path node 
+
+        // Interpret the path node
         var $currElement = this.interpretIndexStepNode(CFIAST.cfiString.path, $("html", contentDocument), classBlacklist, elementBlacklist, idBlacklist);
 
         // Interpret the rest of the steps
@@ -15485,11 +15485,11 @@ EPUBcfi.Interpreter = {
 
     getFirstIndirectionStepNum : function (CFIAST) {
 
-        // Find the first indirection step in the local path; follow it like a regular step, as the step in the content document it 
+        // Find the first indirection step in the local path; follow it like a regular step, as the step in the content document it
         //   references is already loaded and has been passed to this method
         var stepNum = 0;
         for (stepNum; stepNum <= CFIAST.cfiString.localPath.steps.length - 1 ; stepNum++) {
-        
+
             nextStepNode = CFIAST.cfiString.localPath.steps[stepNum];
             if (nextStepNode.type === "indirectionStep") {
                 return stepNum;
@@ -15497,14 +15497,14 @@ EPUBcfi.Interpreter = {
         }
     },
 
-    // REFACTORING CANDIDATE: cfiString node and start step num could be merged into one argument, by simply passing the 
+    // REFACTORING CANDIDATE: cfiString node and start step num could be merged into one argument, by simply passing the
     //   starting step... probably a good idea, this would make the meaning of this method clearer.
     interpretLocalPath : function (localPathNode, startStepNum, $currElement, classBlacklist, elementBlacklist, idBlacklist) {
 
         var stepNum = startStepNum;
         var nextStepNode;
         for (stepNum; stepNum <= localPathNode.steps.length - 1 ; stepNum++) {
-        
+
             nextStepNode = localPathNode.steps[stepNum];
             if (nextStepNode.type === "indexStep") {
 
@@ -15552,9 +15552,9 @@ EPUBcfi.Interpreter = {
 
         // Indirection step
         var $stepTarget = EPUBcfi.CFIInstructions.followIndirectionStep(
-            indirectionStepNode.stepLength, 
-            $currElement, 
-            classBlacklist, 
+            indirectionStepNode.stepLength,
+            $currElement,
+            classBlacklist,
             elementBlacklist);
 
         // Check the id assertion, if it exists
@@ -15571,7 +15571,7 @@ EPUBcfi.Interpreter = {
 
     // REFACTORING CANDIDATE: The logic here assumes that a user will always want to use this terminus
     //   to inject content into the found node. This will not always be the case, and different types of interpretation
-    //   are probably desired. 
+    //   are probably desired.
     interpretTextTerminusNode : function (terminusNode, $currElement, elementToInject) {
 
         if (terminusNode === undefined || terminusNode.type !== "textTerminus") {
@@ -15580,8 +15580,8 @@ EPUBcfi.Interpreter = {
         }
 
         var $injectedElement = EPUBcfi.CFIInstructions.textTermination(
-            $currElement, 
-            terminusNode.offsetValue, 
+            $currElement,
+            terminusNode.offsetValue,
             elementToInject
             );
 
@@ -15594,10 +15594,10 @@ EPUBcfi.Interpreter = {
         var stepNum = 0;
         var nextStepNode;
         for (stepNum = 0 ; stepNum <= localPathNode.steps.length - 1 ; stepNum++) {
-        
+
             nextStepNode = localPathNode.steps[stepNum];
             if (nextStepNode.type === "indexStep") {
-                
+
                 $currElement = this.interpretIndexStepNode(nextStepNode, $currElement, classBlacklist, elementBlacklist, idBlacklist);
             }
             else if (nextStepNode.type === "indirectionStep") {
@@ -15605,7 +15605,7 @@ EPUBcfi.Interpreter = {
                 $currElement = this.interpretIndirectionStepNode(nextStepNode, $currElement, classBlacklist, elementBlacklist, idBlacklist);
             }
 
-            // Found the content document href referenced by the spine item 
+            // Found the content document href referenced by the spine item
             if ($currElement.is("itemref")) {
 
                 return EPUBcfi.CFIInstructions.retrieveItemRefHref($currElement, $packageDocument);
@@ -15615,11 +15615,11 @@ EPUBcfi.Interpreter = {
         return undefined;
     }
 };
-    // Description: This is a set of runtime errors that the CFI interpreter can throw. 
-// Rationale: These error types extend the basic javascript error object so error things like the stack trace are 
-//   included with the runtime errors. 
+    // Description: This is a set of runtime errors that the CFI interpreter can throw.
+// Rationale: These error types extend the basic javascript error object so error things like the stack trace are
+//   included with the runtime errors.
 
-// REFACTORING CANDIDATE: This type of error may not be required in the long run. The parser should catch any syntax errors, 
+// REFACTORING CANDIDATE: This type of error may not be required in the long run. The parser should catch any syntax errors,
 //   provided it is error-free, and as such, the AST should never really have any node type errors, which are essentially errors
 //   in the structure of the AST. This error should probably be refactored out when the grammar and interpreter are more stable.
 EPUBcfi.NodeTypeError = function (node, message) {
@@ -15651,7 +15651,7 @@ EPUBcfi.OutOfRangeError = function (targetIndex, maxIndex, message) {
 };
 
 // REFACTORING CANDIDATE: This is a bit too general to be useful. When I have a better understanding of the type of errors
-//   that can occur with the various terminus conditions, it'll make more sense to revisit this. 
+//   that can occur with the various terminus conditions, it'll make more sense to revisit this.
 EPUBcfi.TerminusError = function (terminusType, terminusCondition, message) {
 
     function TerminusError () {
@@ -15702,7 +15702,7 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
         // Parent element is the same
         if ($(rangeStartElement).parent()[0] === $(rangeEndElement).parent()[0]) {
             range1OffsetStep = this.createCFITextNodeStep($(rangeStartElement), startOffset, classBlacklist, elementBlacklist, idBlacklist);
-            range2OffsetStep = this.createCFITextNodeStep($(rangeEndElement), endOffset, classBlacklist, elementBlacklist, idBlacklist);          
+            range2OffsetStep = this.createCFITextNodeStep($(rangeEndElement), endOffset, classBlacklist, elementBlacklist, idBlacklist);
             commonCFIComponent = this.createCFIElementSteps($(rangeStartElement).parent(), "html", classBlacklist, elementBlacklist, idBlacklist);
             return commonCFIComponent.substring(1, commonCFIComponent.length) + "," + range1OffsetStep + "," + range2OffsetStep;
         }
@@ -15764,8 +15764,8 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
         return commonCFIComponent.substring(1, commonCFIComponent.length) + "," + range1CFI + "," + range2CFI;
     },
 
-    // Description: Generates a character offset CFI 
-    // Arguments: The text node that contains the offset referenced by the cfi, the offset value, the name of the 
+    // Description: Generates a character offset CFI
+    // Arguments: The text node that contains the offset referenced by the cfi, the offset value, the name of the
     //   content document that contains the text node, the package document for this EPUB.
     generateCharacterOffsetCFIComponent : function (startTextNode, characterOffset, classBlacklist, elementBlacklist, idBlacklist) {
 
@@ -15795,7 +15795,7 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
         // Call the recursive method to create all the steps up to the head element of the content document (the "html" element)
         contentDocCFI = this.createCFIElementSteps($(startElement), "html", classBlacklist, elementBlacklist, idBlacklist);
 
-        // Remove the ! 
+        // Remove the !
         return contentDocCFI.substring(1, contentDocCFI.length);
     },
 
@@ -15828,7 +15828,7 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
 
     generateCompleteCFI : function (packageDocumentCFIComponent, contentDocumentCFIComponent) {
 
-        return "epubcfi(" + packageDocumentCFIComponent + contentDocumentCFIComponent + ")";  
+        return "epubcfi(" + packageDocumentCFIComponent + contentDocumentCFIComponent + ")";
     },
 
     // ------------------------------------------------------------------------------------ //
@@ -15836,7 +15836,7 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
     // ------------------------------------------------------------------------------------ //
 
     validateStartTextNode : function (startTextNode, characterOffset) {
-        
+
         // Check that the text node to start from IS a text node
         if (!startTextNode) {
             throw new EPUBcfi.NodeTypeError(startTextNode, "Cannot generate a character offset from a starting point that is not a text node");
@@ -15873,7 +15873,7 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
     },
 
     validatePackageDocument : function (packageDocument, contentDocumentName) {
-        
+
         // Check that the package document is non-empty and contains an itemref element for the supplied idref
         if (!packageDocument) {
             throw new Error("A package document must be supplied to generate a CFI");
@@ -15897,7 +15897,7 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
         var postAssertion;
         var postAssertionEndIndex;
 
-        // Find text node position in the set of child elements, ignoring any blacklisted elements 
+        // Find text node position in the set of child elements, ignoring any blacklisted elements
         $parentNode = $startTextNode.parent();
         $contentsExcludingMarkers = EPUBcfi.CFIInstructions.applyBlacklist($parentNode.contents(), classBlacklist, elementBlacklist, idBlacklist);
 
@@ -15907,7 +15907,7 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
         var textNodeOnlyIndex = 0;
         var characterOffsetSinceUnsplit = 0;
         var finalCharacterOffsetInSequence = 0;
-        $.each($contentsExcludingMarkers, 
+        $.each($contentsExcludingMarkers,
             function (index) {
 
                 // If this is a text node, check if it matches and return the current index
@@ -15915,8 +15915,8 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
 
                     if (this === $startTextNode[0]) {
 
-                        // Set index as the first in the adjacent sequence of text nodes, or as the index of the current node if this 
-                        //   node is a standard one sandwiched between two element nodes. 
+                        // Set index as the first in the adjacent sequence of text nodes, or as the index of the current node if this
+                        //   node is a standard one sandwiched between two element nodes.
                         if (prevNodeWasTextNode) {
                             indexOfTextNode = indexOfFirstInSequence;
                             finalCharacterOffsetInSequence = characterOffsetSinceUnsplit;
@@ -15924,9 +15924,9 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
                         else {
                             indexOfTextNode = textNodeOnlyIndex;
                         }
-                        
+
                         // Break out of .each loop
-                        return false; 
+                        return false;
                     }
 
                     // Save this index as the first in sequence of adjacent text nodes, if it is not already set by this point
@@ -15950,7 +15950,7 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
         CFIIndex = (indexOfTextNode * 2) + 1;
 
         // TODO: text assertions are not in the grammar yet, I think, or they're just causing problems. This has
-        //   been temporarily removed. 
+        //   been temporarily removed.
 
         // Add pre- and post- text assertions
         // preAssertionStartIndex = (characterOffset - 3 >= 0) ? characterOffset - 3 : 0;
@@ -15973,11 +15973,11 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
         var currNodePosition;
         var CFIPosition;
         var idAssertion;
-        var elementStep; 
+        var elementStep;
 
         // Find position of current node in parent list
         $blacklistExcluded = EPUBcfi.CFIInstructions.applyBlacklist($currNode.parent().children(), classBlacklist, elementBlacklist, idBlacklist);
-        $.each($blacklistExcluded, 
+        $.each($blacklistExcluded,
             function (index, value) {
 
                 if (this === $currNode[0]) {
@@ -16005,11 +16005,11 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
         //   top level element.
         $parentNode = $currNode.parent();
         if ($parentNode.is(topLevelElement) || $currNode.is(topLevelElement)) {
-            
+
             // If the top level node is a type from which an indirection step, add an indirection step character (!)
             // REFACTORING CANDIDATE: It is possible that this should be changed to: if (topLevelElement = 'package') do
             //   not return an indirection character. Every other type of top-level element may require an indirection
-            //   step to navigate to, thus requiring that ! is always prepended. 
+            //   step to navigate to, thus requiring that ! is always prepended.
             if (topLevelElement === 'html') {
                 return "!" + elementStep;
             }
@@ -16041,12 +16041,12 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
     var Parser = EPUBcfi.Parser;
     var OError = EPUBcfi.OutOfRangeError;
     var Interp = EPUBcfi.Interpreter;
-    
+
     var NodeTypeError = EPUBcfi.NodeTypeError;
     var OutOfRangeError = EPUBcfi.OutOfRangeError;
     var TerminusError = EPUBcfi.TerminusError;
     var CFIAssertionError = EPUBcfi.CFIAssertionError;
-    
+
     global.EPUBcfi = EPUBcfi =  {
         getContentDocHref : function (CFI, packageDocument) {
             return interpreter.getContentDocHref(CFI, packageDocument);
@@ -16100,12 +16100,12 @@ EPUBcfi.CFIAssertionError = function (expectedAssertion, targetElementAssertion,
     EPUBcfi.OutOfRangeError = OError;
     EPUBcfi.Interpreter = Interp;
     EPUBcfi.Generator = generator;
-    
+
     EPUBcfi.NodeTypeError = NodeTypeError;
     EPUBcfi.OutOfRangeError = OutOfRangeError;
     EPUBcfi.TerminusError = TerminusError;
     EPUBcfi.CFIAssertionError = CFIAssertionError;
-    
+
 }) (typeof window === 'undefined' ? this : window);
 
 define("epubCfi", function(){});
@@ -16674,7 +16674,7 @@ ReadiumSDK.Views.CfiNavigationLogic = function($viewport, $iframe, options){
 
         var $element = $(contentDoc.getElementById(id));
         //$("#" + ReadiumSDK.Helpers.escapeJQuerySelector(id), contentDoc);
-        
+
         if($element.length == 0) {
             return undefined;
         }
@@ -16966,7 +16966,7 @@ ReadiumSDK.Views.OnePageView = function(options){
         width: 0,
         height: 0
     };
-    
+
     var _pageSwitchDir = 0; // 0 => stay on same page, 1 => previous, 2 => next
     var _pageSwitchActuallyChanged = false;
     var _pageSwitchActuallyChanged_IFRAME_LOAD = false;
@@ -16977,11 +16977,11 @@ ReadiumSDK.Views.OnePageView = function(options){
 //console.error("pageSwitchDir _pageSwitchActuallyChanged_IFRAME_LOAD SKIP");
             return;
         }
-        
+
         _pageSwitchDir = dir;
         _pageSwitchActuallyChanged = hasChanged;
     };
-    
+
 
     this.element = function() {
         return _$el;
@@ -17007,11 +17007,8 @@ ReadiumSDK.Views.OnePageView = function(options){
             var template = ReadiumSDK.Helpers.loadTemplate("fixed_page_frame", {});
 
             _$el = $(template);
-        
-            _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-                _$el.css(prefix + "transition", "all 0 ease 0");
-            });
-        
+            _$el.css("transition", "all 0 ease 0");
+
             _$el.css("height", "100%");
             _$el.css("width", "100%");
 
@@ -17043,38 +17040,36 @@ ReadiumSDK.Views.OnePageView = function(options){
             _$epubHtml.css("overflow", "hidden");
             self.applyBookStyles();
             updateMetaSize();
-            
+
             _pageSwitchActuallyChanged_IFRAME_LOAD = true; // second pass, but initial display for transition
-            
+
             self.trigger(ReadiumSDK.Views.OnePageView.SPINE_ITEM_OPENED, _$iframe, _currentSpineItem, self);
         }
     }
 
     this.applyBookStyles = function() {
-        
+
         //TODO: code refactoring candidate? (no CSS override for fixed-layout content, publishers do not like when reading systems mess-up their design)
         return;
-        
+
         if(_$epubHtml) {
             ReadiumSDK.Helpers.setStyles(_bookStyles.getStyles(), _$epubHtml);
         }
     };
-    
+
     this.transformContentImmediate = function(scale, left, top) {
-        
+
         var pageTransition_Translate = false; // TODO: from options
-        
+
         var pageSwitchActuallyChanged = _pageSwitchActuallyChanged || _pageSwitchActuallyChanged_IFRAME_LOAD;
         _pageSwitchActuallyChanged_IFRAME_LOAD = false;
 // console.error("transformContent: "+pageSwitchActuallyChanged + " - " + _pageSwitchDir);
 
         var elWidth = Math.ceil(_meta_size.width * scale);
         var elHeight = Math.floor(_meta_size.height * scale);
-    
-        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-            _$el.css(prefix + "transition", "all 0 ease 0");
-        });
-    
+
+        _$el.css("transition", "all 0 ease 0");
+
         if (pageSwitchActuallyChanged && _enablePageTransitions)
         {
             if (_pageSwitchDir === 0)
@@ -17095,12 +17090,12 @@ ReadiumSDK.Views.OnePageView = function(options){
                 }
             }
         }
-        
+
         _$el.css("left", left + "px");
         _$el.css("top", top + "px");
         _$el.css("width", elWidth + "px");
         _$el.css("height", elHeight + "px");
-                                                    
+
         _$iframe.css("width", elWidth + "px");
         _$iframe.css("height", elHeight + "px");
 
@@ -17120,50 +17115,39 @@ ReadiumSDK.Views.OnePageView = function(options){
         _$epubHtml.css("opacity", "0.999");
 
         _$iframe.css("visibility", "visible");
-        
+
         setTimeout(function()
         {
             //_$epubHtml.css("visibility", "visible");
             _$epubHtml.css("opacity", "1");
         }, 0);
-        
+
         if (pageSwitchActuallyChanged && _enablePageTransitions)
         {
             setTimeout(function()
             {
                 if (_pageSwitchDir === 0)
                 {
-                    _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-                        _$el.css(prefix + "transition", "opacity 250ms linear");
-                    });
-        
+                    _$el.css("transition", "opacity 250ms linear")
                     _$el.css("opacity", "1");
                 }
                 else
                 {
                     if (pageTransition_Translate)
                     {
-                        _$el.css("-webkit-transition", "-webkit-transform 200ms ease-out");
-                        var css = {};
-                        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-                            //css[prefix + 'transition'] = prefix + "transform 200ms ease-out";
-                            css[prefix + 'transform'] = "none";
-                        });
-                        _$el.css(css);
+                        _$el.css("transition", "transform 200ms ease-out");
+                        _$el.css("transform", "none");
                     }
                     else
                     {
-                        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-                            _$el.css(prefix + "transition", "opacity 150ms ease-out");
-                        });
-
+                        _$el.css("transition", "opacity 150ms ease-out");
                         _$el.css("opacity", "1");
                     }
                 }
 
                 // var moveBack = generateTransformCSS(0, 0, 0);
                 // _$el.css(css);
-                //             
+                //
                 //_$el.css("left", left + "px");
 
             }, 10);
@@ -17175,17 +17159,15 @@ ReadiumSDK.Views.OnePageView = function(options){
 
         var translate = (left !== 0 || top !== 0) ? "translate(" + left + "px, " + top + "px)" : undefined;
         var scale = scale !== 1 ? "scale(" + scale + ")" : undefined;
-        
+
         if (!(translate || scale)) return {};
-        
+
         var transformString = (translate && scale) ? (translate + " " + scale) : (translate ? translate : scale); // the order is important!
 
         //TODO modernizer library can be used to get browser independent transform attributes names (implemented in readium-web fixed_layout_book_zoomer.js)
         var css = {};
-        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-            css[prefix + 'transform'] = transformString;
-            css[prefix + 'transform-origin'] = '0 0';
-        });
+        css['transform'] = transformString;
+        css['transform-origin'] = '0 0';
 
         return css;
     }
@@ -17213,7 +17195,7 @@ ReadiumSDK.Views.OnePageView = function(options){
             }
         }
         else { //try to get direct svg or image size
-            
+
             // try SVG element's width/height first
             var $svg = $(contentDocument).find('svg');
             if ($svg.length > 0) {
@@ -17733,13 +17715,10 @@ ReadiumSDK.Views.FixedView = function(options){
         var template = ReadiumSDK.Helpers.loadTemplate("fixed_book_frame", {});
 
         _$el = $(template);
-        
-        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-            _$el.css(prefix + "transition", "all 0 ease 0");
-        });
-        
+
+        _$el.css("transition", "all 0 ease 0");
         _$el.css("overflow", "hidden");
-        
+
         _$viewport.append(_$el);
 
         self.applyStyles();
@@ -17791,7 +17770,7 @@ ReadiumSDK.Views.FixedView = function(options){
 // console.error("updatePageSwitchDir");
 // console.log(dir);
 // console.log(hasChanged);
-// 
+//
         // irrespective of display state
         if (_leftPageView) _leftPageView.pageSwitchDir(dir, hasChanged);
         if (_rightPageView) _rightPageView.pageSwitchDir(dir, hasChanged);
@@ -17802,7 +17781,7 @@ ReadiumSDK.Views.FixedView = function(options){
         //     views[i].pageSwitchDir(dir, hasChanged);
         // }
     };
-    
+
 
     this.applyStyles = function() {
 
@@ -17949,7 +17928,7 @@ ReadiumSDK.Views.FixedView = function(options){
 
         if(bookLeft < 0) bookLeft = 0;
         if(bookTop < 0) bookTop = 0;
-        
+
         _$el.css("left", bookLeft + "px");
         _$el.css("top", bookTop + "px");
         _$el.css("width", targetElementSize.width + "px");
@@ -18060,12 +18039,12 @@ ReadiumSDK.Views.FixedView = function(options){
         var leftItem = _spread.leftItem;
         var rightItem = _spread.rightItem;
         var centerItem = _spread.centerItem;
-        
+
         _spread.openItem(paginationRequest.spineItem);
-        
+
         var hasChanged = leftItem !== _spread.leftItem || rightItem !== _spread.rightItem || centerItem !== _spread.centerItem;
         updatePageSwitchDir(dir === 0 ? 0 : (_spread.spine.isRightToLeft() ? (dir === 1 ? 2 : 1) : dir), hasChanged);
-        
+
         redraw(paginationRequest.initiator, paginationRequest);
     };
 
@@ -18215,7 +18194,7 @@ ReadiumSDK.Views.FixedView = function(options){
         console.error("spine item is not loaded");
         return undefined;
     };
-    
+
     this.getElementByCfi = function(spineItem, cfi, classBlacklist, elementBlacklist, idBlacklist) {
 
         var views = getDisplayingViews();
@@ -18288,15 +18267,15 @@ ReadiumSDK.Views.ReflowableView = function(options){
     _.extend(this, Backbone.Events);
 
     var self = this;
-    
+
     var _$viewport = options.$viewport;
     var _spine = options.spine;
     var _userStyles = options.userStyles;
     var _bookStyles = options.bookStyles;
     var _iframeLoader = options.iframeLoader;
-    
+
     var _currentSpineItem;
-    var _isWaitingFrameRender = false;    
+    var _isWaitingFrameRender = false;
     var _deferredPageRequest;
     var _fontSize = 100;
     var _$contentFrame;
@@ -18428,7 +18407,7 @@ ReadiumSDK.Views.ReflowableView = function(options){
             self.trigger(ReadiumSDK.Events.CONTENT_DOCUMENT_LOAD_START, _$iframe, spineItem);
 
             _$iframe.css("opacity", "0.01");
-            
+
             _iframeLoader.loadIframe(_$iframe[0], src, onIFrameLoad, self, {spineItem : spineItem});
         }
     }
@@ -18443,10 +18422,7 @@ ReadiumSDK.Views.ReflowableView = function(options){
     function updateColumnGap() {
 
         if(_$epubHtml) {
-        
-            _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-                _$epubHtml.css(prefix + "column-gap", _paginationInfo.columnGap + "px");
-            });
+          _$epubHtml.css("column-gap", _paginationInfo.columnGap + "px");
         }
     }
 
@@ -18476,10 +18452,7 @@ ReadiumSDK.Views.ReflowableView = function(options){
 
         _$epubHtml.css("height", _lastViewPortSize.height + "px");
         _$epubHtml.css("position", "relative");
-
-        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-            _$epubHtml.css(prefix + "column-axis", "horizontal");
-        });
+        _$epubHtml.css("column-axis", "horizontal");
 
         self.applyBookStyles();
         resizeImages();
@@ -18490,7 +18463,7 @@ ReadiumSDK.Views.ReflowableView = function(options){
 
 /////////
 //Columns Debugging
-// 
+//
 // _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
 //     _$epubHtml.css(prefix + "column-rule-color", "red");
 //     _$epubHtml.css(prefix + "column-rule-style", "dashed");
@@ -18689,19 +18662,15 @@ ReadiumSDK.Views.ReflowableView = function(options){
 
         // _$epubHtml.css("width", _paginationInfo.columnWidth);
         _$epubHtml.css("width", _lastViewPortSize.width);
-
-        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-            _$epubHtml.css(prefix + "column-width", _paginationInfo.columnWidth + "px");
-        });
-
+        _$epubHtml.css("column-width", _paginationInfo.columnWidth + "px");
 
         var doc = _$iframe[0].contentDocument;
-	    var el = doc.createElementNS("http://www.w3.org/1999/xhtml", "style");
-	    el.appendChild(doc.createTextNode("*{}"));
-	    doc.body.appendChild(el);
-	    doc.body.removeChild(el);
-	    var blocking = doc.body.offsetTop; // browser rendering / layout done
-        
+        var el = doc.createElementNS("http://www.w3.org/1999/xhtml", "style");
+        el.appendChild(doc.createTextNode("*{}"));
+        doc.body.appendChild(el);
+        doc.body.removeChild(el);
+        var blocking = doc.body.offsetTop; // browser rendering / layout done
+
         // resetting the position
         _$epubHtml.css({left: 0, right: 0});
 
@@ -18723,7 +18692,7 @@ ReadiumSDK.Views.ReflowableView = function(options){
         else {
 
             //we get here on resizing the viewport
-            
+
             onPaginationChanged(self); // => redraw() => showBook(), so the trick below is not needed
 
             // //We do this to force re-rendering of the document in the iframe.
@@ -18751,7 +18720,7 @@ ReadiumSDK.Views.ReflowableView = function(options){
     function hideBook()
     {
         if (_currentOpacity != -1) return; // already hidden
-        
+
         _currentOpacity = _$epubHtml.css('opacity');
         _$epubHtml.css('opacity', 0);
     }
@@ -18918,13 +18887,13 @@ ReadiumSDK.Views.ReflowableView = function(options){
 
         var openPageRequest = new ReadiumSDK.Models.PageOpenRequest(_currentSpineItem, initiator);
         openPageRequest.setPageIndex(page);
-        
+
         var id = element.id;
         if (!id)
         {
             id = element.getAttribute("id");
         }
-        
+
         if (id)
         {
             openPageRequest.setElementId(id);
@@ -19178,7 +19147,7 @@ ReadiumSDK.Views.MediaOverlayDataInjector = function (mediaOverlay, mediaOverlay
                             break;
                         }
                     }
-                    
+
                     if (data && (data.par || data.pars))
                     {
                         if (el !== elem)
@@ -19205,28 +19174,28 @@ console.log("MO CLICKED LINK");
                         if (data.pars && (typeof rangy !== "undefined"))
                         {
                             var wasPaused = false;
-                            
+
                             // To remove highlight which may have altered DOM (and break CFI expressions)
                             if (mediaOverlayPlayer.isPlayingCfi())
                             {
                                 wasPaused = true;
                                 mediaOverlayPlayer.pause();
                             }
-                         
+
                             // /////////////////////
-                            // 
+                            //
                             // var p = {x: event.pageX, y: event.pageY};
                             // if (webkitConvertPointFromPageToNode)
                             // {
                             //     p = webkitConvertPointFromPageToNode(elem.ownerDocument.body, new WebKitPoint(event.pageX, event.pageY));
                             // }
-                            // 
+                            //
                             // var div = elem.ownerDocument.getElementById("CLICKED");
                             // if (div)
                             // {
                             //     div.parentNode.removeChild(div);
                             // }
-                            // 
+                            //
                             // div = elem.ownerDocument.createElementNS("http://www.w3.org/1999/xhtml", 'div');
                             // div.setAttribute("style", "background-color: red; position: absolute; z-index: 999; width: 50px; height: 50px; left: " + p.x + "px; top: " + p.y + "px;");
                             // div.id = "CLICKED";
@@ -19234,7 +19203,7 @@ console.log("MO CLICKED LINK");
                             // var divTxt = elem.ownerDocument.createTextNode(" ");
                             // div.appendChild(divTxt);
                             // elem.ownerDocument.body.appendChild(div);
-                            //                          
+                            //
                             // /////////////////////
 
 
@@ -19252,7 +19221,7 @@ console.log("MO CLICKED LINK");
 //                                     r = elem.ownerDocument.createRange();
 //                                     range.setStart(event.rangeParent, event.rangeOffset);
 //                                 }
-//                                 
+//
 // console.log("------ 1");
 // console.log(elem.ownerDocument);
 // console.log(event.pageX);
@@ -19268,7 +19237,7 @@ console.log("MO CLICKED LINK");
 // console.log("------");
 
                                 par = undefined;
-                                
+
                                 for (var iPar = 0; iPar < data.pars.length; iPar++)
                                 {
                                     var p = data.pars[iPar];
@@ -19292,13 +19261,13 @@ console.log("MO CLICKED LINK");
                                         infoStart.textNode[0], infoStart.textOffset,
                                         infoEnd.textNode[0], infoEnd.textOffset
                                     );
-        
+
                                     if (range.isPointInRange(pos.node, pos.offset))
                                     {
 // console.log(p.cfi.partialStartCfi);
 // console.log(p.cfi.partialEndCfi);
                                         // DOUBLE CHECK WITH getClientRects ??
-                                        
+
                                         par = p;
                                         break;
                                     }
@@ -19308,7 +19277,7 @@ console.log("MO CLICKED LINK");
                             {
                                 console.error(e);
                             }
-                            
+
                             if (!par)
                             {
                                 if (wasPaused)
@@ -19368,32 +19337,32 @@ console.debug("MO readaloud attr: " + readaloud);
         var traverseSmilSeqs = function(root)
         {
             if (!root) return;
-            
+
             if (root.nodeType && root.nodeType === "seq")
             {
                // if (root.element)
                // {
                //     console.error("WARN: seq.element already set: " + root.textref);
                // }
-                   
+
                if (root.textref)
                {
                    var parts = root.textref.split('#');
                    var file = parts[0];
                    var fragmentId = (parts.length === 2) ? parts[1] : "";
-                   // 
+                   //
                    // console.debug(root.textref);
                    // console.debug(fragmentId);
                    // console.log("---- SHOULD BE EQUAL:");
                    // console.debug(file);
                    // console.debug(par.text.srcFile);
-                   // 
+                   //
                    // if (file !== par.text.srcFile)
                    // {
                    //     console.error("adjustParToSeqSyncGranularity textref.file !== par.text.srcFile ???");
                    //     return par;
                    // }
-                   // 
+                   //
                    // if (!fragmentId)
                    // {
                    //     console.error("adjustParToSeqSyncGranularity !fragmentId ???");
@@ -19405,9 +19374,9 @@ console.debug("MO readaloud attr: " + readaloud);
                        var textRelativeRef = ReadiumSDK.Helpers.ResolveContentRef(file, smil.href);
                        var same = textRelativeRef === spineItem.href;
                        if (same)
-                       {                       
+                       {
                            root.element = $iframe[0].contentDocument.getElementById(fragmentId);
-                   
+
                            if (!root.element)
                            {
                                console.error("seq.textref !element? " + root.textref);
@@ -19423,7 +19392,7 @@ console.debug("MO readaloud attr: " + readaloud);
                    }
                }
             }
-            
+
             if (root.children && root.children.length)
             {
                 for (var i = 0; i < root.children.length; i++)
@@ -19438,10 +19407,10 @@ console.debug("MO readaloud attr: " + readaloud);
 //console.debug("[[MO ATTACH]] " + spineItem.idref + " /// " + spineItem.media_overlay_id + " === " + smil.id);
 
         var iter = new ReadiumSDK.Models.SmilIterator(smil);
-        
+
         var fakeOpfRoot = "/99!";
         var epubCfiPrefix = "epubcfi";
-        
+
         while (iter.currentPar) {
             iter.currentPar.element = undefined;
             iter.currentPar.cfi = undefined;
@@ -19462,7 +19431,7 @@ console.debug("MO readaloud attr: " + readaloud);
                         if (iter.currentPar.text.srcFragmentId.indexOf(epubCfiPrefix) === 0)
                         {
                             var partial = iter.currentPar.text.srcFragmentId.substr(epubCfiPrefix.length + 1, iter.currentPar.text.srcFragmentId.length - epubCfiPrefix.length - 2);
-                            
+
                             if (partial.indexOf(fakeOpfRoot) === 0)
                             {
                                 partial = partial.substr(fakeOpfRoot.length, partial.length - fakeOpfRoot.length);
@@ -19496,14 +19465,14 @@ console.debug("MO readaloud attr: " + readaloud);
                                         partialRangeCfi: partial,
                                         partialStartCfi: partialStartCfi,
                                         partialEndCfi: partialEndCfi,
-                                        
+
                                         cfiTextParent: cfiTextParent
-                                        
+
                                         // textNode becomes invalid after highlighting! (dynamic span insertion/removal changes DOM)
                                         // cfiRangeStart: infoStart,
                                         // cfiRangeEnd: infoEnd
                                     };
-                                    
+
                                     // TODO: not just start textNode, but all of them between start and end...
                                     // ...that being said, CFI text ranges likely to be used only within a single common parent,
                                     // so this is an acceptable implementation shortcut for this CFI experimentation (word-level text/audio synchronisation).
@@ -19570,7 +19539,7 @@ console.debug("MO readaloud attr: " + readaloud);
                                 }
                             }
                         }
-                        else 
+                        else
                         {
                             console.error("SMIL text@src CFI fragment identifier scheme not supported: " + iter.currentPar.text.srcFragmentId);
                         }
@@ -19794,7 +19763,7 @@ ReadiumSDK.Views.InternalLinksSupport = function(reader) {
             // Check for both href and xlink:href attribute and get value
             var href;
             if (clickEvent.currentTarget.attributes["xlink:href"]) {
-                
+
                 href = clickEvent.currentTarget.attributes["xlink:href"].value;
             }
             else {
@@ -19874,7 +19843,7 @@ ReadiumSDK.Views.IFrameLoader = function() {
     this.loadIframe = function(iframe, src, callback, context) {
 
         //iframe.setAttribute("sandbox", "allow-scripts allow-same-origin");
-        
+
         var isWaitingForFrameLoad = true;
 
         iframe.onload = function() {
@@ -19927,7 +19896,7 @@ define("iframeLoader", ["readiumSDK"], (function (global) {
 }(this)));
 
 var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotationCSSUrl) {
-    
+
     var EpubAnnotations = {};
 
     // Rationale: The order of these matters
@@ -19958,10 +19927,10 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
                 if (this.includeRectInLine(currLine, currRect.top, currRect.left, currRect.width, currRect.height)) {
                     this.expandLine(currLine, currRect.left, currRect.top, currRect.width, currRect.height);
                     rectAppended = true;
-                    break;   
+                    break;
                 }
-            } 
-            
+            }
+
             if (rectAppended) {
                 continue;
             }
@@ -20046,8 +20015,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         return {
             left : rectLeft,
             startTop : rectTop,
-            width : rectWidth, 
-            avgHeight : rectHeight, 
+            width : rectWidth,
+            avgHeight : rectHeight,
             maxTop : rectTop,
             maxBottom : maxBottom,
             numRects : 1
@@ -20056,7 +20025,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
     expandLine : function (currLine, rectLeft, rectTop, rectWidth, rectHeight) {
 
-        var lineOldRight = currLine.left + currLine.width; 
+        var lineOldRight = currLine.left + currLine.width;
 
         // Update all the properties of the current line with rect dimensions
         var rectRight = rectLeft + rectWidth;
@@ -20071,7 +20040,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
         // Expand the line vertically
         currLine = this.expandLineVertically(currLine, rectTop, rectBottom);
-        currLine = this.expandLineHorizontally(currLine, rectLeft, rectRight);        
+        currLine = this.expandLineHorizontally(currLine, rectLeft, rectRight);
 
         return currLine;
     },
@@ -20080,7 +20049,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
         if (rectTop < currLine.maxTop) {
             currLine.maxTop = rectTop;
-        } 
+        }
         if (rectBottom > currLine.maxBottom) {
             currLine.maxBottom = rectBottom;
         }
@@ -20127,7 +20096,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
     highlightGroupCallback : function (event) {
 
         var that = this;
-        
+
         // Trigger this event on each of the highlight views (except triggering event)
         if (event.type === "click") {
             that.get("bbPageSetView").trigger("annotationClicked", "highlight", that.get("CFI"), that.get("id"), event);
@@ -20146,7 +20115,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         _.each(this.get("highlightViews"), function (highlightView) {
 
             if (event.type === "mouseenter") {
-                highlightView.setHoverHighlight();    
+                highlightView.setHoverHighlight();
             }
             else if (event.type === "mouseleave") {
                 highlightView.setBaseHighlight();
@@ -20215,8 +20184,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         this.renderHighlights(viewportElement);
     },
 
-    // REFACTORING CANDIDATE: Ensure that event listeners are being properly cleaned up. 
-    destroyCurrentHighlights : function () { 
+    // REFACTORING CANDIDATE: Ensure that event listeners are being properly cleaned up.
+    destroyCurrentHighlights : function () {
 
         _.each(this.get("highlightViews"), function (highlightView) {
             highlightView.remove();
@@ -20359,8 +20328,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         this.renderUnderlines(viewportElement);
     },
 
-    // REFACTORING CANDIDATE: Ensure that event listeners are being properly cleaned up. 
-    destroyCurrentUnderlines : function () { 
+    // REFACTORING CANDIDATE: Ensure that event listeners are being properly cleaned up.
+    destroyCurrentUnderlines : function () {
 
         _.each(this.get("underlineViews"), function (underlineView) {
             underlineView.remove();
@@ -20388,7 +20357,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
     },
 
     setStyles : function (styles) {
-        
+
         var underlineViews = this.get('underlineViews');
 
         this.set({styles : styles});
@@ -20440,18 +20409,18 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
     EpubAnnotations.ReflowableAnnotations = Backbone.Model.extend({
 
     initialize : function (attributes, options) {
-        
+
         this.epubCFI = EPUBcfi;
         this.annotations = new EpubAnnotations.Annotations({
-            offsetTopAddition : 0, 
-            offsetLeftAddition : 0, 
+            offsetTopAddition : 0,
+            offsetLeftAddition : 0,
             readerBoundElement : $("html", this.get("contentDocumentDOM"))[0],
             scale: 0,
             bbPageSetView : this.get("bbPageSetView")
         });
-        // inject annotation CSS into iframe 
+        // inject annotation CSS into iframe
 
-        
+
         var annotationCSSUrl = this.get("annotationCSSUrl");
         if (annotationCSSUrl)
         {
@@ -20503,7 +20472,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
         // TODO webkit specific?
         var $html = $(this.get("contentDocumentDOM"));
-        var matrix = $('html', $html).css('-webkit-transform');
+        var matrix = $('html', $html).css('transform');
         var scale = new WebKitCSSMatrix(matrix).a;
         this.set("scale", scale);
 
@@ -20520,7 +20489,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
             // Get start and end marker for the id, using injected into elements
             // REFACTORING CANDIDATE: Abstract range creation to account for no previous/next sibling, for different types of
-            //   sibiling, etc. 
+            //   sibiling, etc.
             rangeStartNode = CFIRangeInfo.startElement.nextSibling ? CFIRangeInfo.startElement.nextSibling : CFIRangeInfo.startElement;
             rangeEndNode = CFIRangeInfo.endElement.previousSibling ? CFIRangeInfo.endElement.previousSibling : CFIRangeInfo.endElement;
             range = document.createRange();
@@ -20539,7 +20508,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             }
 
             return {
-                CFI : CFI, 
+                CFI : CFI,
                 selectedElements : selectionInfo.selectedElements
             };
 
@@ -20571,7 +20540,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
             return {
 
-                CFI : CFI, 
+                CFI : CFI,
                 selectedElements : $injectedElement[0]
             };
 
@@ -20598,7 +20567,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
             return {
 
-                CFI : CFI, 
+                CFI : CFI,
                 selectedElements : $targetImage[0]
             };
 
@@ -20655,11 +20624,11 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
                 annotationInfo = this.addHighlight(CFI, id, type, styles);
             }
 
-            // Rationale: The annotationInfo object returned from .addBookmark(...) contains the same value of 
+            // Rationale: The annotationInfo object returned from .addBookmark(...) contains the same value of
             //   the CFI variable in the current scope. Since this CFI variable contains a "hacked" CFI value -
             //   only the content document portion is valid - we want to replace the annotationInfo.CFI property with
             //   the partial content document CFI portion we originally generated.
-            annotationInfo.CFI = generatedContentDocCFI;            
+            annotationInfo.CFI = generatedContentDocCFI;
             return annotationInfo;
         }
         else {
@@ -20681,7 +20650,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             CFI = "epubcfi(" + arbitraryPackageDocCFI + generatedContentDocCFI + ")";
             annotationInfo = this.addBookmark(CFI, id, type);
 
-            // Rationale: The annotationInfo object returned from .addBookmark(...) contains the same value of 
+            // Rationale: The annotationInfo object returned from .addBookmark(...) contains the same value of
             //   the CFI variable in the current scope. Since this CFI variable contains a "hacked" CFI value -
             //   only the content document portion is valid - we want to replace the annotationInfo.CFI property with
             //   the partial content document CFI portion we originally generated.
@@ -20716,7 +20685,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             CFI = "epubcfi(" + arbitraryPackageDocCFI + generatedContentDocCFI + ")";
             annotationInfo = this.addImageAnnotation(CFI, id);
 
-            // Rationale: The annotationInfo object returned from .addBookmark(...) contains the same value of 
+            // Rationale: The annotationInfo object returned from .addBookmark(...) contains the same value of
             //   the CFI variable in the current scope. Since this CFI variable contains a "hacked" CFI value -
             //   only the content document portion is valid - we want to replace the annotationInfo.CFI property with
             //   the partial content document CFI portion we originally generated.
@@ -20754,11 +20723,11 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         }
 
         this.findSelectedElements(
-            selectedRange.commonAncestorContainer, 
-            selectedRange.startContainer, 
+            selectedRange.commonAncestorContainer,
+            selectedRange.startContainer,
             selectedRange.endContainer,
             intervalState,
-            selectedElements, 
+            selectedElements,
             elementType
         );
 
@@ -20783,9 +20752,9 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             endOffset = selectedRange.endOffset;
 
             rangeCFIComponent = this.epubCFI.generateCharOffsetRangeComponent(
-                startNode, 
-                startOffset, 
-                endNode, 
+                startNode,
+                startOffset,
+                endNode,
                 endOffset,
                 ["cfi-marker", "mo-cfi-highlight"],
                 [],
@@ -20860,7 +20829,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             }
             else {
                 if ($(currElement).is(elementType)) {
-                    selectedElements.push(currElement);    
+                    selectedElements.push(currElement);
                 }
             }
         });
@@ -21052,7 +21021,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
         var bookmarkView = new EpubAnnotations.BookmarkView({
             CFI : CFI,
-            targetElement : targetElement, 
+            targetElement : targetElement,
             offsetTopAddition : offsetTop,
             offsetLeftAddition : offsetLeft,
             id : annotationId.toString(),
@@ -21082,8 +21051,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
         delete annotationHash[annotationId];
 
-        highlights = _.reject(highlights, 
-                              function(obj) { 
+        highlights = _.reject(highlights,
+                              function(obj) {
                                   if (obj.id == annotationId) {
                                       obj.destroyCurrentHighlights();
                                       return true;
@@ -21113,7 +21082,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             selectedNodes : highlightedTextNodes,
             offsetTopAddition : offsetTop,
             offsetLeftAddition : offsetLeft,
-            styles: styles, 
+            styles: styles,
             id : annotationId,
             bbPageSetView : this.get("bbPageSetView"),
             scale: this.get("scale")
@@ -21174,7 +21143,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         return annotationViews;
     },
 
-    // REFACTORING CANDIDATE: Some kind of hash lookup would be more efficient here, might want to 
+    // REFACTORING CANDIDATE: Some kind of hash lookup would be more efficient here, might want to
     //   change the implementation of the annotations as an array
     validateAnnotationId : function (id) {
 
@@ -21198,7 +21167,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
         this.bookmark = new EpubAnnotations.Bookmark({
             CFI : options.CFI,
-            targetElement : options.targetElement, 
+            targetElement : options.targetElement,
             offsetTopAddition : options.offsetTopAddition,
             offsetLeftAddition : options.offsetLeftAddition,
             id : options.id,
@@ -21233,7 +21202,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         if (this.bookmark.get("type") === "comment") {
             absoluteTop = this.bookmark.getAbsoluteTop();
             absoluteLeft = this.bookmark.getAbsoluteLeft();
-            this.$el.css({ 
+            this.$el.css({
                 "top" : absoluteTop + "px",
                 "left" : absoluteLeft + "px",
                 "width" : "50px",
@@ -21276,9 +21245,9 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             type = "bookmark";
         }
 
-        this.bookmark.get("bbPageSetView").trigger("annotationClicked", 
-            type, 
-            this.bookmark.get("CFI"), 
+        this.bookmark.get("bbPageSetView").trigger("annotationClicked",
+            type,
+            this.bookmark.get("CFI"),
             this.bookmark.get("id"),
             this.$el.css("top"),
             this.$el.css("left"),
@@ -21340,8 +21309,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
     setCSS : function () {
 
         var styles = this.highlight.get("styles") || {};
-        
-        this.$el.css({ 
+
+        this.$el.css({
             "top" : this.highlight.get("top") + "px",
             "left" : this.highlight.get("left") + "px",
             "height" : this.highlight.get("height") + "px",
@@ -21428,8 +21397,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
     setCSS : function () {
         var styles = this.underline.get("styles") || {};
-        
-        this.$el.css({ 
+
+        this.$el.css({
             "top" : this.underline.get("top") + "px",
             "left" : this.underline.get("left") + "px",
             "height" : this.underline.get("height") + "px",
@@ -21441,7 +21410,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             "background-color" : styles.fill_color || "normal",
         });
 
-        
+
         this.$underlineElement.addClass("underline");
     },
 
@@ -21467,11 +21436,11 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 });
 
     // Rationale: An image annotation does NOT have a view, as we don't know the state of an image element within an EPUB; it's entirely
-//   possible that an EPUB image element could have a backbone view associated with it already, which would cause problems if we 
+//   possible that an EPUB image element could have a backbone view associated with it already, which would cause problems if we
 //   tried to associate another backbone view. As such, this model modifies CSS properties for an annotated image element.
-//   
+//
 //   An image annotation view that manages an absolutely position element (similar to bookmarks, underlines and highlights) can be
-//   added if more functionality is required. 
+//   added if more functionality is required.
 
 EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
 
@@ -21497,11 +21466,10 @@ EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
     },
 
     setCSS : function () {
-        
+
         $(this.get("imageNode")).css({
             "border" : "5px solid rgb(255, 0, 0)",
             "border" : "5px solid rgba(255, 0, 0, 0.2)",
-            "-webkit-background-clip" : "padding-box",
             "background-clip" : "padding-box"
         });
     },
@@ -21524,7 +21492,7 @@ EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
 
 
     var reflowableAnnotations = new EpubAnnotations.ReflowableAnnotations({
-        contentDocumentDOM : contentDocumentDOM, 
+        contentDocumentDOM : contentDocumentDOM,
         bbPageSetView : bbPageSetView,
         annotationCSSUrl : annotationCSSUrl,
     });
@@ -21532,46 +21500,46 @@ EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
     // Description: The public interface
     return {
 
-        addSelectionHighlight : function (id, type, styles) { 
-            return reflowableAnnotations.addSelectionHighlight(id, type, styles); 
+        addSelectionHighlight : function (id, type, styles) {
+            return reflowableAnnotations.addSelectionHighlight(id, type, styles);
         },
-        addSelectionBookmark : function (id, type) { 
-            return reflowableAnnotations.addSelectionBookmark(id, type); 
+        addSelectionBookmark : function (id, type) {
+            return reflowableAnnotations.addSelectionBookmark(id, type);
         },
         addSelectionImageAnnotation : function (id) {
             return reflowableAnnotations.addSelectionImageAnnotation(id);
         },
-        addHighlight : function (CFI, id, type, styles) { 
-            return reflowableAnnotations.addHighlight(CFI, id, type, styles); 
+        addHighlight : function (CFI, id, type, styles) {
+            return reflowableAnnotations.addHighlight(CFI, id, type, styles);
         },
-        addBookmark : function (CFI, id, type) { 
+        addBookmark : function (CFI, id, type) {
             return reflowableAnnotations.addBookmark(CFI, id, type);
         },
-        addImageAnnotation : function (CFI, id) { 
-            return reflowableAnnotations.addImageAnnotation(CFI, id); 
+        addImageAnnotation : function (CFI, id) {
+            return reflowableAnnotations.addImageAnnotation(CFI, id);
         },
         updateAnnotationView : function (id, styles) {
             return reflowableAnnotations.updateAnnotationView(id, styles);
         },
-        redraw : function () { 
-            return reflowableAnnotations.redraw(); 
+        redraw : function () {
+            return reflowableAnnotations.redraw();
         },
-        getBookmark : function (id) { 
-            return reflowableAnnotations.annotations.getBookmark(id); 
+        getBookmark : function (id) {
+            return reflowableAnnotations.annotations.getBookmark(id);
         },
-        getBookmarks : function () { 
-            return reflowableAnnotations.annotations.getBookmarks(); 
-        }, 
-        getHighlight : function (id) { 
-            return reflowableAnnotations.annotations.getHighlight(id); 
+        getBookmarks : function () {
+            return reflowableAnnotations.annotations.getBookmarks();
         },
-        getHighlights : function () { 
-            return reflowableAnnotations.annotations.getHighlights(); 
+        getHighlight : function (id) {
+            return reflowableAnnotations.annotations.getHighlight(id);
         },
-        getUnderline : function (id) { 
-            return reflowableAnnotations.annotations.getUnderline(id); 
+        getHighlights : function () {
+            return reflowableAnnotations.annotations.getHighlights();
         },
-        getUnderlines : function () { 
+        getUnderline : function (id) {
+            return reflowableAnnotations.annotations.getUnderline(id);
+        },
+        getUnderlines : function () {
             return reflowableAnnotations.annotations.getUnderlines();
         },
         getImageAnnotation : function () {
@@ -21579,7 +21547,7 @@ EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
         },
         getImageAnnotations : function () {
 
-        }, 
+        },
         removeAnnotation: function (annotationId) {
             return reflowableAnnotations.remove(annotationId);
         },
@@ -21603,7 +21571,7 @@ define("annotations_module", ["epubCfi"], (function (global) {
 }(this)));
 
 //  Created by Dmitry Markushevich (dmitrym@evidentpoint.com)
-// 
+//
 //  Copyright (c) 2012-2013 The Readium Foundation.
 //
 //  The Readium SDK is free software: you can redistribute it and/or modify
@@ -21647,7 +21615,7 @@ Before proceeding with the highlighting workflow it is sometimes necessary to de
 	> RReader.getCurrentSelectionCfi()
 	Object {idref: "id-id2604743", cfi: "/4/2/6,/1:74,/1:129"}
 
-The response contains a partial CFI that is sufficient to create a highlight based on selection. If nothing is selected *undefined* is returned. 
+The response contains a partial CFI that is sufficient to create a highlight based on selection. If nothing is selected *undefined* is returned.
 
 You can also use partial Cfi with `openSpineItemElementCfi()` to navigate to where this selection is later.
 
@@ -21675,7 +21643,7 @@ Alternatively, you can call addSelectionHighlight(). It combines both getCurrent
 Note that it provides no validation. If nothing is selected, `undefined` is returned.
 
 
-## Removing highlights 
+## Removing highlights
 
 To remove the highlight, call `removeHighlight`:
 
@@ -21695,11 +21663,11 @@ When a user clicks on a highlight `annotationClicked` event is dispatched with t
 
 	> RReader.on('annotationClicked', function(type, idref, cfi, annotationId) { console.log (type, idref, cfi, annotationId)});
 	ReadiumSDK.Views.ReaderView {on: function, once: function, off: function, trigger: function, listenTo: function…}
-	
+
 Then when the user clicks on the highlight the following will show up in the console:
 
-	highlight id-id2604743 /4/2/6,/1:74,/1:129 123 
-	
+	highlight id-id2604743 /4/2/6,/1:74,/1:129 123
+
 
 */
 
@@ -21709,7 +21677,7 @@ ReadiumSDK.Views.AnnotationsManager = function (proxyObj, options) {
     var self = this;
     var liveAnnotations = {};
     var spines = {};
-    var proxy = proxyObj; 
+    var proxy = proxyObj;
     var annotationCSSUrl = options.annotationCSSUrl;
 
     if (!annotationCSSUrl) {
@@ -21721,7 +21689,7 @@ ReadiumSDK.Views.AnnotationsManager = function (proxyObj, options) {
     // we want to bubble up all of the events that annotations module may trigger up.
     this.on("all", function(eventName) {
         var args = Array.prototype.slice.call(arguments);
-        // mangle annotationClicked event. What really needs to happen is, the annotation_module needs to return a 
+        // mangle annotationClicked event. What really needs to happen is, the annotation_module needs to return a
         // bare Cfi, and this class should append the idref.
         var annotationClickedEvent = 'annotationClicked';
         if (args.length && args[0] === annotationClickedEvent) {
@@ -21757,7 +21725,7 @@ ReadiumSDK.Views.AnnotationsManager = function (proxyObj, options) {
 
     this.getCurrentSelectionCfi = function() {
         for(var spine in liveAnnotations) {
-            var annotationsForView = liveAnnotations[spine]; 
+            var annotationsForView = liveAnnotations[spine];
             var partialCfi = annotationsForView.getCurrentSelectionCFI();
             if (partialCfi) {
                 return {"idref":spines[spine].idref, "cfi":partialCfi};
@@ -21768,7 +21736,7 @@ ReadiumSDK.Views.AnnotationsManager = function (proxyObj, options) {
 
     this.addSelectionHighlight = function(id, type) {
         for(spine in liveAnnotations) {
-            var annotationsForView = liveAnnotations[spine]; 
+            var annotationsForView = liveAnnotations[spine];
             if (annotationsForView.getCurrentSelectionCFI()) {
                 var annotation = annotationsForView.addSelectionHighlight(id, type);
                 annotation.idref = spines[spine].idref;
@@ -21782,7 +21750,7 @@ ReadiumSDK.Views.AnnotationsManager = function (proxyObj, options) {
         for(var spine in liveAnnotations) {
             if (spines[spine].idref === spineIdRef) {
                 var fakeCfi = "epubcfi(/99!" + partialCfi + ")";
-                var annotationsForView = liveAnnotations[spine]; 
+                var annotationsForView = liveAnnotations[spine];
                 var annotation = annotationsForView.addHighlight(fakeCfi, id, type, styles);
                 annotation.idref = spineIdRef;
                 annotation.CFI = getPartialCfi(annotation.CFI);
@@ -21795,7 +21763,7 @@ ReadiumSDK.Views.AnnotationsManager = function (proxyObj, options) {
     this.removeHighlight = function(id) {
         var result = undefined;
         for(var spine in liveAnnotations) {
-            var annotationsForView = liveAnnotations[spine]; 
+            var annotationsForView = liveAnnotations[spine];
             result  = annotationsForView.removeHighlight(id);
         }
         return result;
@@ -22376,7 +22344,7 @@ ReadiumSDK.Views.ScrollView = function(options){
 
         return _navigationLogic.getElementById(id);
     };
-    
+
     this.getElement = function(spineItem, selector) {
 
         if(spineItem != _currentSpineItem) {
@@ -22550,7 +22518,7 @@ ReadiumSDK.Views.ReaderView = function(options) {
     var _annotationsManager = new ReadiumSDK.Views.AnnotationsManager(self, options);
 
     var _enablePageTransitions = options.enablePageTransitions;
-    
+
     if (options.el instanceof $) {
         _$el = options.el;
         console.log("** EL is a jQuery selector:" + options.el.attr('id'));
@@ -22619,7 +22587,7 @@ ReadiumSDK.Views.ReaderView = function(options) {
 
             // performance degrades with large DOM (e.g. word-level text-audio sync)
             _mediaOverlayDataInjector.attachMediaOverlayData($iframe, spineItem, _viewerSettings);
-            
+
             _internalLinksSupport.processLinkElements($iframe, spineItem);
             _annotationsManager.attachAnnotations($iframe, spineItem);
 
@@ -22704,7 +22672,7 @@ ReadiumSDK.Views.ReaderView = function(options) {
         _spine = _package.spine;
 
         if(_mediaOverlayPlayer) {
-            
+
             _mediaOverlayPlayer.reset();
         }
 
@@ -22817,7 +22785,7 @@ ReadiumSDK.Views.ReaderView = function(options) {
             var bookMark = _currentView.bookmarkCurrentPage();
 
             if(bookMark) {
-            
+
                 var wasPlaying = false;
                 if (_currentView.isReflowable && _currentView.isReflowable())
                 {
@@ -23240,7 +23208,7 @@ ReadiumSDK.Views.ReaderView = function(options) {
     this.isMediaOverlayAvailable = function() {
 
         if (!_mediaOverlayPlayer) return false;
-        
+
         return _mediaOverlayPlayer.isMediaOverlayAvailable();
     };
 
@@ -23314,7 +23282,7 @@ ReadiumSDK.Views.ReaderView = function(options) {
 
         return _mediaOverlayPlayer.isPlaying();
     };
-    
+
 //
 // should use ReadiumSDK.Events.SETTINGS_APPLIED instead!
 //    this.setRateMediaOverlay = function(rate) {
@@ -23345,7 +23313,7 @@ ReadiumSDK.Views.ReaderView = function(options) {
 
     this.handleViewportResize = function(){
         if (_currentView){
-            
+
             var wasPlaying = false;
             if (_currentView.isReflowable && _currentView.isReflowable())
             {
@@ -23355,7 +23323,7 @@ ReadiumSDK.Views.ReaderView = function(options) {
                     self.pauseMediaOverlay();
                 }
             }
-            
+
             _currentView.onViewportResize();
 
             if (wasPlaying)
@@ -24395,7 +24363,7 @@ define('epub-model/package_document_parser',['require', 'module', 'jquery', 'und
         // http://idpf.org/epub/30/spec/epub30-mediaoverlays.html#app-clock-examples
         function resolveClockValue(value) {
             if (!value) return 0;
-            
+
             var hours = 0;
             var mins = 0;
             var secs = 0;
@@ -24587,8 +24555,8 @@ define('epub-model/package_document_parser',['require', 'module', 'jquery', 'und
             jsonMetadata.rights = getElemText(metadataElem, "rights");
             jsonMetadata.spread = $("meta[property='rendition:spread']", $metadata).text();
             jsonMetadata.title = getElemText(metadataElem, "title");
-            
-            
+
+
             // Media part
             jsonMetadata.mediaItems = [];
 
@@ -24600,12 +24568,12 @@ define('epub-model/package_document_parser',['require', 'module', 'jquery', 'und
                   duration: resolveClockValue($($currItem).text())
                });
             });
-               
+
             jsonMetadata.mediaDuration =  resolveClockValue($("meta[property='media:duration']:not([refines])", $metadata).text());
             jsonMetadata.mediaNarrator =  $("meta[property='media:narrator']", $metadata).text();
             jsonMetadata.mediaActiveClass =   $("meta[property='media:active-class']", $metadata).text();
             jsonMetadata.mediaPlaybackActiveClass =   $("meta[property='media:playback-active-class']", $metadata).text();
-            
+
             return jsonMetadata;
         }
 
@@ -24629,8 +24597,8 @@ define('epub-model/package_document_parser',['require', 'module', 'jquery', 'und
                     media_type: $currManifestElement.attr("media-type") ? $currManifestElement.attr("media-type") : "",
                     properties: $currManifestElement.attr("properties") ? $currManifestElement.attr("properties") : ""
                 };
-                // console.log('pushing manifest item to JSON manifest. currManifestElementHref: [' + currManifestElementHref + 
-                //     '], manifestItem.contentDocumentURI: [' + manifestItem.contentDocumentURI + 
+                // console.log('pushing manifest item to JSON manifest. currManifestElementHref: [' + currManifestElementHref +
+                //     '], manifestItem.contentDocumentURI: [' + manifestItem.contentDocumentURI +
                 //     '], manifestItem:');
                 // console.log(manifestItem);
                 jsonManifest.push(manifestItem);
@@ -25056,7 +25024,7 @@ define('epub-model/package_document',['require', 'module', 'jquery', 'underscore
             _spine.each(function (spineItem) {
                 spinePackageData.push(generatePackageData(spineItem));
             });
-            
+
             // This is where the package data format thing is generated
             return {
                 rootUrl : packageDocRoot,
@@ -25064,7 +25032,7 @@ define('epub-model/package_document',['require', 'module', 'jquery', 'underscore
                 media_overlay : getMediaOverlay(),
                 spine : {
                     direction : pageProgressionDirection(),
-                    items : spinePackageData    
+                    items : spinePackageData
                 }
             };
         };
@@ -25076,14 +25044,14 @@ define('epub-model/package_document',['require', 'module', 'jquery', 'underscore
                  activeClass : _metadata.get('mediaActiveClass'),
                  playbackActiveClass : _metadata.get('mediaPlaybackActiveClass'),
                  smil_models : _moMap,
-                 
+
                  skippables: ["sidebar", "practice", "marginalia", "annotation", "help", "note", "footnote", "rearnote", "table", "table-row", "table-cell", "list", "list-item", "pagebreak"],
                  escapables: ["sidebar", "bibliography", "toc", "loi", "appendix", "landmarks", "lot", "index", "colophon", "epigraph", "conclusion", "afterword", "warning", "epilogue", "foreword", "introduction", "prologue", "preface", "preamble", "notice", "errata", "copyright-page", "acknowledgments", "other-credits", "titlepage", "imprimatur", "contributors", "halftitlepage", "dedication", "help", "annotation", "marginalia", "practice", "note", "footnote", "rearnote", "footnotes", "rearnotes", "bridgehead", "page-list", "table", "table-row", "table-cell", "list", "list-item", "glossary"]
            };
 
            return result;
         }
-        
+
         function isFixedLayout() {
 
             return _metadata.get("fixed_layout");
@@ -25385,7 +25353,7 @@ define('epub-model/package_document',['require', 'module', 'jquery', 'underscore
             });
         };
 
-        // 
+        //
         this.getEpub3Toc = function(callback) {
             this.generateTocListDOM(function(dom) {
                 var olTocList =  $($('nav#toc', dom)[0]).children()[0];
@@ -25644,7 +25612,7 @@ define('epub-model/smil_document_parser',[ 'require', 'module', 'jquery', 'under
             if (destProperty === "type") {
                 destProperty = "epubtype";
             }
-            
+
             if (fromNode.getAttribute(property) != undefined) {
                 toItem[destProperty] = fromNode.getAttribute(property);
             } else if (isRequired) {
@@ -25662,7 +25630,7 @@ define('epub-model/smil_document_parser',[ 'require', 'module', 'jquery', 'under
         // http://idpf.org/epub/30/spec/epub30-mediaoverlays.html#app-clock-examples
         function resolveClockValue(value) {
             if (!value) return 0;
-            
+
             var hours = 0;
             var mins = 0;
             var secs = 0;
@@ -25711,7 +25679,7 @@ define('epub-model/smil_document_parser',[ 'require', 'module', 'jquery', 'under
         function createItemFromElement(element) {
             var item = {};
             item.nodeType = element.nodeName;
-            
+
             var isBody = false;
             if (item.nodeType === "body")
             {
@@ -25759,7 +25727,7 @@ define('epub-model/smil_document_parser',[ 'require', 'module', 'jquery', 'under
 
     };
 
-    
+
     function fillSmilData(docJson, bookRoot, jsLibRoot, currentResourceFetcher, callback) {
 
         if (docJson.spine.length <= 0) {
@@ -25770,7 +25738,7 @@ define('epub-model/smil_document_parser',[ 'require', 'module', 'jquery', 'under
 
         var allFakeSmil = true;
         docJson.mo_map = [];
-        
+
         var processSpineItem = function(ii) {
 
             if (ii >= docJson.spine.length) {
@@ -25782,9 +25750,9 @@ define('epub-model/smil_document_parser',[ 'require', 'module', 'jquery', 'under
                 callback(docJson);
                 return;
             }
-            
+
             var spineItem = docJson.spine[ii];
-            
+
             var manifestItem = undefined;
             for (var jj = 0; jj < docJson.manifest.length; jj++) {
                 var item = docJson.manifest[jj];
@@ -25798,9 +25766,9 @@ define('epub-model/smil_document_parser',[ 'require', 'module', 'jquery', 'under
                 processSpineItem(ii+1);
                 return;
             }
-            
+
             if (manifestItem.media_overlay) {
-            
+
                 var manifestItemSMIL = undefined;
                 for (var jj = 0; jj < docJson.manifest.length; jj++) {
                     var item = docJson.manifest[jj];
@@ -25815,7 +25783,7 @@ define('epub-model/smil_document_parser',[ 'require', 'module', 'jquery', 'under
                     return;
                 }
                 //ASSERT manifestItemSMIL.media_type === "application/smil+xml"
-                
+
                 var smilParser = new SmilDocumentParser(currentResourceFetcher, manifestItemSMIL.href);
                 smilParser.parse(function(smilJson) {
                     smilJson.href = manifestItemSMIL.href;
@@ -25826,7 +25794,7 @@ define('epub-model/smil_document_parser',[ 'require', 'module', 'jquery', 'under
                         for (var idx = 0; idx < docJson.metadata.mediaItems.length; idx++) {
                             var item = docJson.metadata.mediaItems[idx];
                             if (!item.refines) continue;
-                            
+
                             var id = item.refines;
                             var hash = id.indexOf('#');
                             if (hash >= 0) {
@@ -25845,7 +25813,7 @@ define('epub-model/smil_document_parser',[ 'require', 'module', 'jquery', 'under
 
                     allFakeSmil = false;
                     docJson.mo_map.push(smilJson);
-                    
+
                     setTimeout(function(){ processSpineItem(ii+1); }, 0);
                     return;
                 });
@@ -25869,21 +25837,21 @@ define('epub-model/smil_document_parser',[ 'require', 'module', 'jquery', 'under
                         }]
                     }]
                 });
-                
+
                 setTimeout(function(){ processSpineItem(ii+1); }, 0);
                 return;
             }
         };
-        
+
         processSpineItem(0);
     }
-    
-    
+
+
     var SmilParser = {
         fillSmilData: fillSmilData,
         Parser: SmilDocumentParser
     }
-    
+
     return SmilParser;
 });
 
@@ -25894,7 +25862,7 @@ define('epub-model/smil_document_parser',[ 'require', 'module', 'jquery', 'under
  * Licensed under the MIT license */
 
 (function(window, undefined) {
-  
+
 
 /**
  * Hammer
@@ -26599,7 +26567,7 @@ Hammer.PointerEvent = {
     Hammer.utils.each(self.pointers, function(pointer){
       touchlist.push(pointer);
     });
-    
+
     return touchlist;
   },
 
@@ -26869,31 +26837,31 @@ Hammer.gestures.Drag = {
   index    : 50,
   defaults : {
     drag_min_distance            : 10,
-    
+
     // Set correct_for_drag_min_distance to true to make the starting point of the drag
     // be calculated from where the drag was triggered, not from where the touch started.
     // Useful to avoid a jerk-starting drag, which can make fine-adjustments
     // through dragging difficult, and be visually unappealing.
     correct_for_drag_min_distance: true,
-    
+
     // set 0 for unlimited, but this can conflict with transform
     drag_max_touches             : 1,
-    
+
     // prevent default browser behavior when dragging occurs
     // be careful with it, it makes the element a blocking element
     // when you are using the drag gesture, it is a good practice to set this true
     drag_block_horizontal        : false,
     drag_block_vertical          : false,
-    
+
     // drag_lock_to_axis keeps the drag gesture on the axis that it started on,
     // It disallows vertical directions if the initial direction was horizontal, and vice versa.
     drag_lock_to_axis            : false,
-    
+
     // drag lock only kicks in when distance > drag_lock_min_distance
     // This way, locking occurs only when the distance has become large enough to reliably determine the direction
     drag_lock_min_distance       : 25
   },
-  
+
   triggered: false,
   handler  : function dragGesture(ev, inst) {
     // current gesture isnt drag, but dragged is true
@@ -27270,7 +27238,7 @@ Hammer.gestures.Transform = {
  *
  * Copyright (c) 2014 Jorik Tangelder <j.tangelder@gmail.com>;
  * Licensed under the MIT license */(function(window, undefined) {
-  
+
 
 function setup(Hammer, $) {
   /**
@@ -27372,7 +27340,7 @@ function setup(Hammer, $) {
   if(typeof define == 'function' && typeof define.amd == 'object' && define.amd) {
     // define as an anonymous module
     define('jquery_hammer',['hammer', 'jquery'], setup);
-  
+
   }
   else {
     setup(window.Hammer, window.jQuery || window.Zepto);
@@ -27498,7 +27466,7 @@ define('Readium',['require', 'module', 'console_shim', 'jquery', 'underscore', '
                         }
                         self.reader.openBook(openBookData);
 
-                        var options = { 
+                        var options = {
                             packageDocumentUrl : _currentResourceFetcher.getPackageUrl(),
                             metadata: docJson.metadata
                         };


### PR DESCRIPTION
jQuery (since v1.8) automagically adds prefix when necessary, by detecting if browser supports the standard rule or a prefixed one.
