### PR TITLE
Fixed typo in default reader settings

### DIFF
--- a/lib/EpubReader.js
+++ b/lib/EpubReader.js
@@ -695,7 +695,7 @@ catch (e)
             else{
                 readium.reader.updateSettings({
                     syntheticSpread:  "auto",
-                    scrolling: "auto"
+                    scroll: "auto"
                 });
             }
             


### PR DESCRIPTION
Found a little typo in the default settings for the reader. The option seems to be called "scroll" instead of "scrolling" in readium-js-shared.
