### PR TITLE
Fixes # 146

### DIFF
--- a/lib/ReaderSettingsDialog.js
+++ b/lib/ReaderSettingsDialog.js
@@ -84,6 +84,18 @@ define(['hgn!templates/settings-dialog.html', 'ReaderSettingsDialog_Keyboard', '
             $("#tab-main").attr('aria-expanded', "false");
             $("#tab-keyboard").attr('aria-expanded', "true");
         });
+        $('#buttSave').on('keydown',function(evt) {
+            if(evt.which === 9 && !(evt.shiftKey | evt.ctrlKey | evt.metaKey | evt.altKey)) { // TAB pressed
+              evt.preventDefault();
+              $('#closeSettingsCross').focus();
+            }
+        });
+        $('#closeSettingsCross').on('keydown',function(evt) {
+            if(evt.which === 9 && evt.shiftKey) { // shift-TAB pressed
+              evt.preventDefault();
+              $('#buttSave').focus();
+            }
+        });
         
         $('#settings-dialog').on('hide.bs.modal', function(){ // IMPORTANT: not "hidden.bs.modal"!! (because .off() in
         


### PR DESCRIPTION
Added onkeydown trap of shift-tab/tab on first and last elements
in settings to keep focus in dialog until closed.

Tested in ChromeExtension, Chrome, Safari on OS X 10.9.4 with VoiceOver.
Testing in IE 11, Firefox 31, Chrome 36 with JAWS 15 on Windows 7. 

This also fixes #147 which was closed but still had problems.
