### PR TITLE
some themes don't style book title

### DIFF
--- a/css/viewer.css
+++ b/css/viewer.css
@@ -139,6 +139,30 @@ html[data-theme=night-theme] .modal
     color: black;
 }
 
+html[data-theme=parchment-theme] .book-title-header,
+html[data-theme=parchment-theme] body,
+html[data-theme=parchment-theme] #readium-toc-body
+{
+  background-color: #f7f1cf;
+  color: #774c27;
+}
+
+html[data-theme=ballard-theme] .book-title-header,
+html[data-theme=ballard-theme] body,
+html[data-theme=ballard-theme] #readium-toc-body
+{
+  background-color: #576b96;
+  color: #DDD;
+}
+
+html[data-theme=vancouver-theme] .book-title-header,
+html[data-theme=vancouver-theme] body,
+html[data-theme=vancouver-theme] #readium-toc-body
+{
+  background-color: #DDD;
+  color: #576b96;
+}
+
 /*.icon-show-hide, .icon-show-hide:active{
   display: none;
 }*/


### PR DESCRIPTION
In the screenshots below, notice how the book title has a different background than the rest of the book.  This is _especially_ distracting when I'm reading books in full screen:
![screenshot 2014-09-18 at 10 12 05 am](https://cloud.githubusercontent.com/assets/9863/4324110/129f3aa6-3f57-11e4-9831-af938b100f9f.png) ![screenshot 2014-09-18 at 10 12 28 am](https://cloud.githubusercontent.com/assets/9863/4324109/129c08c2-3f57-11e4-8b00-207c2b1d1e03.png) ![screenshot 2014-09-18 at 10 13 00 am](https://cloud.githubusercontent.com/assets/9863/4324108/1291feb8-3f57-11e4-91bd-297f006ab649.png)

Please update these themes to style the book title with the same background color as the book.

Thanks for your consideration.
