### PR TITLE
hyperlinks hard to read in dark themes

### DIFF
--- a/css/annotations.css
+++ b/css/annotations.css
@@ -54,3 +54,7 @@
     height: 85%;
     background-color: transparent;
 }
+
+a {
+  color: CornflowerBlue !important;
+}


### PR DESCRIPTION
In dark themes, hyperlinks are hard to read:
![screenshot 2014-09-18 at 10 07 47 am](https://cloud.githubusercontent.com/assets/9863/4324031/56e500b6-3f56-11e4-87c9-85606ccd4135.png)
![screenshot 2014-09-18 at 10 07 35 am](https://cloud.githubusercontent.com/assets/9863/4324033/59dbcc14-3f56-11e4-8e13-cb47a33294ca.png)

Please add styles for `a` elements in the dark themes.

Thanks for your consideration.
