### PR TITLE
Missing lib/thirdparty/inflate.js external files in cloud reader builds

### DIFF
--- a/extend_require_config.js
+++ b/extend_require_config.js
@@ -19,7 +19,8 @@ require.config({
 	config : {
     	'EpubReader' : {
             'useSimpleLoader' : false, // the cloud reader cannot pre-process HTML content documents and may need to load zipped EPUBs too (strictly-speaking, this config option is false by default, but we prefer to have it explicitly set here).
-            'mathJaxUrl' : '/lib/mathjax/MathJax.js'
+            'mathJaxUrl' : '/lib/mathjax/MathJax.js',
+            'jsLibRoot' : './lib/thirdparty/'
     	}
     }
 });

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -90,6 +90,16 @@ module.exports = function(grunt) {
                 cwd: 'lib',
                 src: 'mathjax/**',
                 dest: 'build/cloud-reader/scripts'
+            }, {
+                expand: true,
+                cwd: 'lib/thirdparty/',
+                src: 'inflate.js',
+                dest: 'build/cloud-reader/scripts/zip'
+            }, {
+                expand: true,
+                cwd: 'lib/thirdparty/',
+                src: 'deflate.js',
+                dest: 'build/cloud-reader/scripts/zip'
             } ]
         },
         cloudReaderEpubContent: {
@@ -142,7 +152,17 @@ module.exports = function(grunt) {
                 cwd: 'lib',
                 src: 'mathjax/**',
                 dest: 'build/cloud-reader-lite/scripts'
-            } ]
+            }, {
+                expand: true,
+                cwd: 'lib/thirdparty/',
+                src: 'inflate.js',
+                dest: 'build/cloud-reader-lite/scripts/zip'
+            }, {
+                expand: true,
+                cwd: 'lib/thirdparty/',
+                src: 'deflate.js',
+                dest: 'build/cloud-reader-lite/scripts/zip'
+            }  ]
         }
         // prepareChromeAppTests: {
         //     files: [{

--- a/grunt/requirejs.js
+++ b/grunt/requirejs.js
@@ -65,11 +65,16 @@ module.exports = function(grunt) {
                     'versioning/Versioning' : 'versioning/PackagedVersioning',
                     'viewer-version' : '../build/version.json'
                 },
-                // TODO: pass these config parameters so they are picked-up by module.config() in EpubReader.js (readerOptions object)
+                
+                // JUST FOR TESTING! (non-minified source code)
+                //optimize: "none" 
+                
+                // TODO: pass these config parameters so they are picked-up by module.config() in EpubReader.js (readerOptions and readiumOptions objects)
                 // config : {
                 //     'EpubReader' : {
                 //         'useSimpleLoader' : false, // the cloud reader cannot pre-process HTML content documents and may need to load zipped EPUBs too (strictly-speaking, this config option is false by default, but we prefer to have it explicitly set here).
-                //         'mathJaxUrl' : '/scripts/mathjax/MathJax.js'
+                //         'mathJaxUrl' : '/scripts/mathjax/MathJax.js',
+                //         jsLibRoot: './scripts/zip/',
                 //     }
                 // }
             }
@@ -85,11 +90,16 @@ module.exports = function(grunt) {
                     'versioning/Versioning' : 'versioning/PackagedVersioning',
                     'viewer-version' : '../build/version.json'
                 },
-                // TODO: pass these config parameters so they are picked-up by module.config() in EpubReader.js (readerOptions object)
+                
+                // JUST FOR TESTING! (non-minified source code)
+                //optimize: "none" 
+                
+                // TODO: pass these config parameters so they are picked-up by module.config() in EpubReader.js (readerOptions and readiumOptions objects)
                 // config : {
                 //     'EpubReader' : {
                 //         'useSimpleLoader' : false, // the cloud reader cannot pre-process HTML content documents and may need to load zipped EPUBs too (strictly-speaking, this config option is false by default, but we prefer to have it explicitly set here).
                 //         'mathJaxUrl' : '/scripts/mathjax/MathJax.js'
+                //         jsLibRoot: './scripts/zip/',
                 //     }
                 // }
             }

--- a/lib/EpubReader.js
+++ b/lib/EpubReader.js
@@ -677,7 +677,7 @@ Readium){
             };
 
             var readiumOptions = {
-                jsLibRoot: './lib/thirdparty/',
+                jsLibRoot: module.config().jsLibRoot || './scripts/zip/',
                 openBookOptions: {}
             };
 

--- a/lib/Readium.js
+++ b/lib/Readium.js
@@ -367,7 +367,7 @@ define('text',['module'], function (module) {
     return text;
 });
 
-define('text!version.json',[],function () { return '{"readiumJs":{"sha":"f7bbacaa158537d0cdf535923ad30c7226194a57","tag":"Release-0.10-391-gf7bbaca","clean":false},"readiumSharedJs":{"sha":"8303a0bc1ebc00aceb0c8246a225c436d4e18a3c","tag":"Release-0.10-473-g8303a0b","clean":true}}';});
+define('text!version.json',[],function () { return '{"readiumJs":{"sha":"e6171061a054bd9bb3b97dce88502acdc1e2b126","tag":"Release-0.10-392-ge617106","clean":true},"readiumSharedJs":{"sha":"8303a0bc1ebc00aceb0c8246a225c436d4e18a3c","tag":"Release-0.10-473-g8303a0b","clean":true}}';});
 
 /*
 This code is required to IE for console shim
@@ -27553,8 +27553,8 @@ define('epub-fetch/zip_resource_fetcher',['require', 'module', 'jquery', 'URIjs'
 
             } else {
 
-                //true by default, requires standalone inflate/deflate.js (not aggregated/minified/optimised in generated build)
-                //zip.useWebWorkers = false;
+                // The Web Worker requires standalone inflate/deflate.js files in libDir (i.e. cannot be aggregated/minified/optimised in the final generated single-file build)
+                zip.useWebWorkers = true; // (true by default)
                 zip.workerScriptsPath = libDir;
                 
                 _zipFs = new zip.fs.FS();

--- a/lib/Readium.js
+++ b/lib/Readium.js
@@ -367,7 +367,7 @@ define('text',['module'], function (module) {
     return text;
 });
 
-define('text!version.json',[],function () { return '{"readiumJs":{"sha":"f7bbacaa158537d0cdf535923ad30c7226194a57","tag":"Release-0.10-391-gf7bbaca","clean":true},"readiumSharedJs":{"sha":"8303a0bc1ebc00aceb0c8246a225c436d4e18a3c","tag":"Release-0.10-473-g8303a0b","clean":true}}';});
+define('text!version.json',[],function () { return '{"readiumJs":{"sha":"f7bbacaa158537d0cdf535923ad30c7226194a57","tag":"Release-0.10-391-gf7bbaca","clean":false},"readiumSharedJs":{"sha":"8303a0bc1ebc00aceb0c8246a225c436d4e18a3c","tag":"Release-0.10-473-g8303a0b","clean":true}}';});
 
 /*
 This code is required to IE for console shim
@@ -27553,7 +27553,10 @@ define('epub-fetch/zip_resource_fetcher',['require', 'module', 'jquery', 'URIjs'
 
             } else {
 
+                //true by default, requires standalone inflate/deflate.js (not aggregated/minified/optimised in generated build)
+                //zip.useWebWorkers = false;
                 zip.workerScriptsPath = libDir;
+                
                 _zipFs = new zip.fs.FS();
                 _zipFs.importHttpContent(baseUrl, true, function () {
 


### PR DESCRIPTION
Addresses https://github.com/readium/readium-js-viewer/issues/270
