### PR TITLE
Show specific error message on ajax error

### DIFF
--- a/i18n/_locales/en_US/messages.json
+++ b/i18n/_locales/en_US/messages.json
@@ -81,6 +81,9 @@
   "err_epub_corrupt" : {
     "message": "Invalid or corrupted EPUB package"
   },
+  "err_ajax": {
+    "message": "Error in ajax request"
+  },  
   "err_dlg_title" : {
     "message": "Unexpected Error"
   },

--- a/lib/Dialogs.js
+++ b/lib/Dialogs.js
@@ -40,8 +40,11 @@ define(['hgn!templates/managed-dialog.html', 'hgn!templates/progress-dialog.html
 					msg = Strings.err_storage;
 					break;
 				case Messages.ERROR_EPUB:
-					msg = Strings.err_epub_corrupt
+					msg = Strings.err_epub_corrupt;
 					break;
+        			case Messages.ERROR_AJAX:
+        				msg = Strings.err_ajax;
+                			break;					
 				default: 
 					msg = Strings.err_unknown;
 					console.trace();


### PR DESCRIPTION
When an error occurs in ajax requests, it is used the error code ERROR_AJAX.

This code is now being ignored when displaying the error message to user. This patch fix it using a new label in messages file.