### PR TITLE
drag-n-drop, directly open local files in cloud reader, import in Chrome app library

### DIFF
--- a/src/css/readium_js.css
+++ b/src/css/readium_js.css
@@ -13,6 +13,13 @@ body {
     box-sizing:border-box;
 	-moz-box-sizing:border-box; /* Firefox */
 	-webkit-box-sizing:border-box; /* Safari */
+    
+}
+
+body.fileDragHover {
+-webkit-box-shadow: inset 0px 0px 32px 0px blue;
+-moz-box-shadow: inset 0px 0px 32px 0px blue;
+box-shadow: inset 0px 0px 32px 0px blue;
 }
 
 iframe {

--- a/src/css/viewer.css
+++ b/src/css/viewer.css
@@ -284,7 +284,8 @@ html[data-theme=night-theme] #right-page-btn:hover
 
 /* show outline on reading-area when iframe gets focus */
 .contentFocus {
-    box-shadow: 0px 0px 5px #6fb5f1 !important;
+    /* box-shadow: 0px 0px 5px #6fb5f1 !important; */
+    
     outline: #6fb5f1 dotted 1px !important;
     
     outline-offset: -3px;

--- a/src/js/EpubLibrary.js
+++ b/src/js/EpubLibrary.js
@@ -191,8 +191,8 @@ Versioning){
 
 	var readClick = function(e){
 
-		var epubUrl = $(this).attr('data-book');
-		$(window).triggerHandler('readepub', [epubUrl]);
+		var ebookURL = $(this).attr('data-book');
+		$(window).triggerHandler('readepub', [ebookURL]);
 		return false;
 	}
 
@@ -240,9 +240,8 @@ Versioning){
 		libraryManager.retrieveAvailableEpubs(loadLibraryItems);
 	}
 
-	var handleFileSelect = function(evt){
-		var file = evt.target.files[0];
-		$('#add-epub-dialog').modal('hide');
+	var importZippedEpub = function(file) {
+		
 		Dialogs.showModalProgress(Strings.import_dlg_title, Strings.import_dlg_message);
 		libraryManager.handleZippedEpub({
 			file: file,
@@ -251,7 +250,13 @@ Versioning){
 			progress: Dialogs.updateProgress,
 			error: showError
 		});
+	};
 
+	var handleFileSelect = function(evt){
+		$('#add-epub-dialog').modal('hide');
+		
+		var file = evt.target.files[0];
+		importZippedEpub(file);
 	}
 
 	var handleDirSelect = function(evt){
@@ -266,6 +271,7 @@ Versioning){
 			error: showError
 		});
 	}
+	
 	var handleUrlSelect = function(){
 		var url = $('#url-upload').val();
 		$('#add-epub-dialog').modal('hide');
@@ -278,6 +284,16 @@ Versioning){
 			error: showError
 		});
 	}
+
+	var importEpub = function(ebook) {
+		
+		// TODO: also allow import of URL and directory select
+		// See libraryManager.canHandleUrl() + handleUrlSelect()
+		// See libraryManager.canHandleDirectory() + handleDirSelect()
+		
+		if (!window.File || !(ebook instanceof File)) return;
+		importZippedEpub(ebook);
+	};
 
 	var doMigration = function(){
 		Dialogs.showModalProgress(Strings.migrate_dlg_title, Strings.migrate_dlg_message);
@@ -405,14 +421,14 @@ Versioning){
 		});
 	}
 
-    var applyKeyboardSettingsAndLoadUi = function(data)
+    var applyKeyboardSettingsAndLoadUi = function()
     {
         // override current scheme with user options
         Settings.get('reader', function(json)
         {
            Keyboard.applySettings(json);
 
-           loadLibraryUI(data);
+           loadLibraryUI();
         });
     };
     window.setReplaceByDefault = function(replace){
@@ -420,6 +436,7 @@ Versioning){
     }
 	return {
         loadUI : applyKeyboardSettingsAndLoadUi,
-        unloadUI : unloadLibraryUI
+        unloadUI : unloadLibraryUI,
+		importEpub : importEpub 
 	};
 });

--- a/src/js/ReadiumViewerLite.js
+++ b/src/js/ReadiumViewerLite.js
@@ -3,8 +3,9 @@ define(['jquery', './EpubReader', 'readium_shared_js/helpers'], function($, Epub
     $(function(){
 
 	    var urlParams = Helpers.getURLQueryParams();
-
-			// embedded, epub
+	
+		// embedded, epub
+		// (epub is ebookURL)
       EpubReader.loadUI(urlParams);
 
 		$(document.body).on('click', function()
@@ -27,4 +28,49 @@ define(['jquery', './EpubReader', 'readium_shared_js/helpers'], function($, Epub
 	}).on('show.bs.tooltip', function(e){
 		$(tooltipSelector).not(e.target).tooltip('destroy');
 	});
+	
+	
+	
+	
+	if (window.File
+	 	//&& window.FileReader
+	 ) {
+		var fileDragNDropHTMLArea = $(document.body);
+		fileDragNDropHTMLArea.on("dragover", function(ev) {
+			ev.stopPropagation();
+			ev.preventDefault();
+			
+			//$(ev.target)
+			fileDragNDropHTMLArea.addClass("fileDragHover");
+		});
+		fileDragNDropHTMLArea.on("dragleave", function(ev) {
+			ev.stopPropagation();
+			ev.preventDefault();
+			
+			//$(ev.target)
+			fileDragNDropHTMLArea.removeClass("fileDragHover");
+		});
+		fileDragNDropHTMLArea.on("drop", function(ev) {
+			ev.stopPropagation();
+			ev.preventDefault();
+			
+			//$(ev.target)
+			fileDragNDropHTMLArea.removeClass("fileDragHover");
+			
+			var files = ev.target.files || ev.originalEvent.dataTransfer.files;
+			if (files.length) {
+				var file = files[0];
+				console.log("File drag-n-drop:");
+				console.log(file.name);
+				console.log(file.type);
+				console.log(file.size);
+				
+				if (file.type == "application/epub+zip" || (/\.epub$/.test(file.name))) {
+					
+      				EpubReader.loadUI({epub: file});
+				}
+			}
+		});
+	}
+
 });


### PR DESCRIPTION
Implements https://github.com/readium/readium-js-viewer/issues/225
drag-n-drop support to directly open local files in cloud reader, see https://github.com/readium/readium-js/pull/115
and to import zipped EPUB files in Chrome app / extension (without having to open the library's import dialog)