### PR TITLE
Remove errant comma from viewer_audio.css

### DIFF
--- a/src/css/viewer_audio.css
+++ b/src/css/viewer_audio.css
@@ -252,7 +252,6 @@
     
     cursor: pointer;
 }
-,
 
 #volume-range-slider:active,
 #time-range-slider:active,


### PR DESCRIPTION
Just a minor typo fix.  I don't even know if there is a noticeable symptom as I haven't used audio yet.  Mainly just wanted to clear the IDE red flag. :)