### PR TITLE
Fixes #434 Tooltips may not close

### DIFF
--- a/src/js/ReadiumViewer.js
+++ b/src/js/ReadiumViewer.js
@@ -215,6 +215,10 @@ define(['jquery', './EpubLibrary', './EpubReader', 'readium_shared_js/helpers'],
         container: 'body' // do this to prevent weird navbar re-sizing issue when the tooltip is inserted
     }).on('show.bs.tooltip', function(e){
         $(tooltipSelector).not(e.target).tooltip('destroy');
+        var target = e.target; 
+        setTimeout(function(){
+            $(target).tooltip('destroy');
+        }, 8000);
     });
     
     

--- a/src/js/ReadiumViewerLite.js
+++ b/src/js/ReadiumViewerLite.js
@@ -27,6 +27,10 @@ define(['jquery', './EpubReader', 'readium_shared_js/helpers'], function($, Epub
         container: 'body' // do this to prevent weird navbar re-sizing issue when the tooltip is inserted
     }).on('show.bs.tooltip', function(e){
         $(tooltipSelector).not(e.target).tooltip('destroy');
+        var target = e.target; 
+        setTimeout(function(){
+            $(target).tooltip('destroy');
+        }, 8000);
     });
     
     


### PR DESCRIPTION
Modified the tooltip code to destroy the
tooltip after 8 seconds

I used 8 seconds because Chrome and Safari display a title tooltip for ~10 seconds, IE 11 for ~5, and Opera and Firefox indefinitely (latest versions of browsers tested on Windows 7 and OS X 10.11).  

The only slight issues is that if you leave and return to the same tooltip the 8 seconds the counter is not reset.  For example, using the keyboard with 
ToC NOT displayed, tab to the ToC button, sit for a few seconds, press enter to activate, focus moves to the TOC close button, immediately press enter to close the ToC and put focus back on the toolbar ToC button.  If you do all that in less than 8 seconds the prompt will disappear after the original 8 second time has completed.  The same thing happens if you open and close the settings dialog within the 8 seconds. I don't see this as an issue as someone needing more than 8 seconds to read the prompt is likely not moving that quickly. 