### PR TITLE
Fixes #488 Dialogs not working with screen readers

### DIFF
--- a/src/templates/add-epub-dialog.html
+++ b/src/templates/add-epub-dialog.html
@@ -1,4 +1,4 @@
-<div class="modal fade" id="add-epub-dialog" tabindex="-1" role="dialog" aria-labelledby="add-epub-label" aria-hidden="true">
+<div class="modal fade" id="add-epub-dialog" tabindex="-1" role="dialog" aria-labelledby="add-epub-label">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
@@ -20,14 +20,14 @@
                 <div id="epub-upload-div" class="form-group">
                     <label id="add2" class="control-label col-sm-5">{{strings.i18n_from_local_file}}</label>
                     <div class="col-sm-7">
-                        <input tabindex="1000" type="file" id="epub-upload" class="form-control" aria-labelledby="add2" role="button">
+                        <input tabindex="1000" type="file" id="epub-upload" class="form-control" aria-labelledby="add2">
                     </div>
                 </div>
                 {{#canHandleDirectory}}
                 <div class="form-group">
                     <label id="add3" class="control-label col-sm-5">{{strings.i18n_unpacked_directory}}</label>
                     <div class="col-sm-7">
-                        <input tabindex="1000" type="file" id="dir-upload" webkitdirectory="" mozdirectory="" directory="" class="form-control" aria-labelledby="add3"  role="button">
+                        <input tabindex="1000" type="file" id="dir-upload" webkitdirectory="" mozdirectory="" directory="" class="form-control" aria-labelledby="add3">
                     </div>
                 </div>
                 {{/canHandleDirectory}}

--- a/src/templates/settings-dialog.html
+++ b/src/templates/settings-dialog.html
@@ -1,4 +1,4 @@
-<div tabindex="-1" class="modal fade" id="settings-dialog" role="dialog" aria-label="{{strings.settings}}" aria-hidden="true">
+<div tabindex="-1" class="modal fade" id="settings-dialog" role="dialog" aria-label="{{strings.settings}}">
     <div class="modal-dialog">
         <div class="modal-content">
 


### PR DESCRIPTION
Fixed the issue with screen readers not speaking the settings and add to library dialog.  This was due to aria-hidden=true being initialized on the dialogs and never being removed.  

I also removed the role=button on the input type=file element in the add to library dialog.  This role was preventing the browser generated browse file system button from working properly with screen readers. 