### PR TITLE
Fixes #491 - Font Size changes not spoken

### DIFF
--- a/src/templates/settings-dialog.html
+++ b/src/templates/settings-dialog.html
@@ -34,7 +34,7 @@
                             <img src="{{{imagePathPrefix}}}images/glyphicons_115_text_smaller.png" alt="" aria-hidden="true">
                         </div>
                         <div class="col-xs-8">
-                            <input  type="range" role="slider" aria-labelledby="setting-header-font-size" id="font-size-input" min="60" aria-value-min="60" aria-valuemin="60" step="10" max="170" aria-value-max="170" aria-valuemax="170" value="100" aria-valuenow="100" aria-value-now="100" aria-valuetext="1em" aria-value-text="1em" title="{{strings.i18n_font_size}}" aria-label="{{strings.i18n_font_size}}" />
+                            <input  type="range" aria-labelledby="setting-header-font-size" id="font-size-input" min="60" aria-value-min="60" aria-valuemin="60" step="10" max="170" aria-value-max="170" aria-valuemax="170" value="100" aria-valuenow="100" aria-value-now="100" aria-valuetext="1em" aria-value-text="1em" title="{{strings.i18n_font_size}}" aria-label="{{strings.i18n_font_size}}" />
                         </div>
                         <div class="col-xs-2">
                             <img src="{{{imagePathPrefix}}}images/glyphicons_116_text_bigger.png" alt="" aria-hidden="true">


### PR DESCRIPTION
Changes to the font size slider were not
spoken by the screen readers. This was due to the
role=slider attribute conflicting with the default
input type=range. Removing the role fixed the problem.

This will only work once feature/488ScreenReader has been applied.