### PR TITLE
Fixes #252 Tooltip format on prev/next buttons

### DIFF
--- a/src/js/EpubReader.js
+++ b/src/js/EpubReader.js
@@ -537,7 +537,7 @@ Helpers){
             hideUI();
         }
         else{
-            hideTimeoutId = window.setTimeout(hideUI, 4000);
+            hideTimeoutId = window.setTimeout(hideUI, 8000);
         }
     }
 

--- a/src/js/EpubReader.js
+++ b/src/js/EpubReader.js
@@ -130,7 +130,12 @@ Helpers){
                 }));
                 $("#left-page-btn").on("click", prevPage);
                 $("#right-page-btn").on("click", nextPage);
-    
+                $("#left-page-btn").mouseleave(function() {
+                  $(tooltipSelector()).tooltip('destroy');
+                });
+                $("#right-page-btn").mouseleave(function() {
+                  $(tooltipSelector()).tooltip('destroy');
+                });
             },
             openPageRequest
         );

--- a/src/js/EpubReader.js
+++ b/src/js/EpubReader.js
@@ -74,6 +74,10 @@ Helpers){
     // (bad naming convention, hard to find usages of "el")
     var el = document.documentElement;
 
+    var tooltipSelector = function() {
+        return 'nav *[title], #readium-page-btns *[title]';
+    };
+   
     function setBookTitle(title) {
     
         var $titleEl = $('.book-title-header');
@@ -515,6 +519,8 @@ Helpers){
             hideLoop();
             return;  
         } 
+
+        $(tooltipSelector()).tooltip('destroy');
 
         $(document.body).addClass('hide-ui');
     }
@@ -1124,7 +1130,8 @@ Helpers){
 
     return {
         loadUI : applyKeyboardSettingsAndLoadUi,
-        unloadUI : unloadReaderUI
+        unloadUI : unloadReaderUI,
+        tooltipSelector : tooltipSelector
     };
 
 });

--- a/src/js/ReadiumViewer.js
+++ b/src/js/ReadiumViewer.js
@@ -79,7 +79,7 @@ define(['jquery', './EpubLibrary', './EpubReader', 'readium_shared_js/helpers'],
     }
 
 
-    var tooltipSelector = 'nav *[title]';
+    var tooltipSelector = 'nav *[title], #readium-page-btns *[title]';
 
     var libraryView = function(libraryURL, importEPUB){
         $(tooltipSelector).tooltip('destroy');
@@ -211,7 +211,15 @@ define(['jquery', './EpubLibrary', './EpubReader', 'readium_shared_js/helpers'],
 
     $(document.body).tooltip({
         selector : tooltipSelector,
-        placement: 'auto',
+        placement: function(tip, element){
+          var placeValue = 'auto';
+          if (element.id == 'left-page-btn'){
+            placeValue = 'right';
+          } else if (element.id == 'right-page-btn') {
+            placeValue = 'left'
+          }
+          return placeValue;
+        },
         container: 'body' // do this to prevent weird navbar re-sizing issue when the tooltip is inserted
     }).on('show.bs.tooltip', function(e){
         $(tooltipSelector).not(e.target).tooltip('destroy');

--- a/src/js/ReadiumViewer.js
+++ b/src/js/ReadiumViewer.js
@@ -78,11 +78,8 @@ define(['jquery', './EpubLibrary', './EpubReader', 'readium_shared_js/helpers'],
         };
     }
 
-
-    var tooltipSelector = 'nav *[title], #readium-page-btns *[title]';
-
     var libraryView = function(libraryURL, importEPUB){
-        $(tooltipSelector).tooltip('destroy');
+        $(EpubReader.tooltipSelector()).tooltip('destroy');
         
         EpubReader.unloadUI();
         EpubLibrary.unloadUI();
@@ -96,7 +93,7 @@ define(['jquery', './EpubLibrary', './EpubReader', 'readium_shared_js/helpers'],
     }
 
     var readerView = function(data){
-        $(tooltipSelector).tooltip('destroy');
+        $(EpubReader.tooltipSelector()).tooltip('destroy');
         
         EpubLibrary.unloadUI();
         EpubReader.unloadUI();
@@ -210,7 +207,7 @@ define(['jquery', './EpubLibrary', './EpubReader', 'readium_shared_js/helpers'],
     });
 
     $(document.body).tooltip({
-        selector : tooltipSelector,
+        selector : EpubReader.tooltipSelector(),
         placement: function(tip, element){
           var placeValue = 'auto';
           if (element.id == 'left-page-btn'){
@@ -222,7 +219,7 @@ define(['jquery', './EpubLibrary', './EpubReader', 'readium_shared_js/helpers'],
         },
         container: 'body' // do this to prevent weird navbar re-sizing issue when the tooltip is inserted
     }).on('show.bs.tooltip', function(e){
-        $(tooltipSelector).not(e.target).tooltip('destroy');
+        $(EpubReader.tooltipSelector()).not(e.target).tooltip('destroy');
         var target = e.target; 
         setTimeout(function(){
             $(target).tooltip('destroy');

--- a/src/js/ReadiumViewerLite.js
+++ b/src/js/ReadiumViewerLite.js
@@ -19,11 +19,19 @@ define(['jquery', './EpubReader', 'readium_shared_js/helpers'], function($, Epub
         });
     });
 
-    var tooltipSelector = 'nav *[title]';
+    var tooltipSelector = 'nav *[title], #readium-page-btns *[title]';
 
     $(document.body).tooltip({
         selector : tooltipSelector,
-        placement: 'auto',
+        placement: function(tip, element){
+          var placeValue = 'auto';
+          if (element.id == 'left-page-btn'){
+            placeValue = 'right';
+          } else if (element.id == 'right-page-btn') {
+            placeValue = 'left'
+          }
+          return placeValue;
+        },
         container: 'body' // do this to prevent weird navbar re-sizing issue when the tooltip is inserted
     }).on('show.bs.tooltip', function(e){
         $(tooltipSelector).not(e.target).tooltip('destroy');

--- a/src/js/ReadiumViewerLite.js
+++ b/src/js/ReadiumViewerLite.js
@@ -19,10 +19,8 @@ define(['jquery', './EpubReader', 'readium_shared_js/helpers'], function($, Epub
         });
     });
 
-    var tooltipSelector = 'nav *[title], #readium-page-btns *[title]';
-
     $(document.body).tooltip({
-        selector : tooltipSelector,
+        selector : EpubReader.tooltipSelector(),
         placement: function(tip, element){
           var placeValue = 'auto';
           if (element.id == 'left-page-btn'){
@@ -34,7 +32,7 @@ define(['jquery', './EpubReader', 'readium_shared_js/helpers'], function($, Epub
         },
         container: 'body' // do this to prevent weird navbar re-sizing issue when the tooltip is inserted
     }).on('show.bs.tooltip', function(e){
-        $(tooltipSelector).not(e.target).tooltip('destroy');
+        $(EpubReader.tooltipSelector()).not(e.target).tooltip('destroy');
         var target = e.target; 
         setTimeout(function(){
             $(target).tooltip('destroy');


### PR DESCRIPTION
The prev/next page buttons were using the default browser title
tooltips rather than the bootstrap tooltips used on the other buttons.
Now all are the same and the prev/next button tooltips should be properly
placed. Note that I also increased the hideLoop timeout from 4 to 8
seconds to match the timer on the display of tooltips.