### PR TITLE
Refs #488 about-dialog has aria-hidden

### DIFF
--- a/src/templates/about-dialog.html
+++ b/src/templates/about-dialog.html
@@ -1,4 +1,4 @@
-<div class="modal fade" id="about-dialog" tabindex="-1" role="dialog" aria-label="{{{strings.about}}}" aria-hidden="true">
+<div class="modal fade" id="about-dialog" tabindex="-1" role="dialog" aria-label="{{{strings.about}}}" >
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-body">


### PR DESCRIPTION
Removed aria-hidden from the about-dialog.  The screen readers were still speaking the dialog title but having aria-hidden was incorrect since the visibility of the dialog is controlled via CSS.


### Related issue(s), pull request(s)
#489
See also #NUMBER

### This pull request is:
Finalize

### Test cases, sample files

Test the about dialog is correctly announced by screen readers.  Also tested that screen readers do not speak the dialog when it is not visible. 


### Additional information

...
removed aria-hidden from About dialog. It is not needed since
hide/show is controlled via css