### PR TITLE
fixes #542 - no message when invalid keyboard shortcuts saved

### DIFF
--- a/src/i18n/_locales/en_US/messages.json
+++ b/src/i18n/_locales/en_US/messages.json
@@ -129,6 +129,9 @@
   "i18n_keyboard_reload" : {
     "message" : "Please reload the page for keyboard shortcuts to take effect."
   },
+  "i18n_keyboard_onerror_reset" : {
+    "message" : "Please note: Any shortcuts marked INVALID or DUPLICATE have been reset to original values."
+  },
   "i18n_reset_key" : {
     "message" : "Reset key"
   },
@@ -312,7 +315,7 @@
   },
 
   "i18n_html_readium_tm_a_project" : {
-    "message" : "Readium for Chrome is the Chrome browser extension configuration of ReadiumJS, an open source reading system and JavaScript library for displaying EPUB® publications in web browsers. ReadiumJS is a project of the Readium Foundation (Readium.org). To learn more or to contribute, visit the <a href=\"http://readium.org/projects/readiumjs\">project homepage</a>"
+    "message" : "Readium for Chrome is the Chrome browser extension configuration of ReadiumJS, an open source reading system and JavaScript library for displaying EPUB® publications in web browsers. ReadiumJS is a project of the Readium Foundation (Readium.org). To learn more or to contribute, visit the <a id=\"aboutFirst Focusable\" href=\"http://readium.org/projects/readiumjs\">project homepage</a>"
   },
   "i18n_toolbar" : {
     "message" : "Toolbar"

--- a/src/js/ReaderSettingsDialog_Keyboard.js
+++ b/src/js/ReaderSettingsDialog_Keyboard.js
@@ -289,6 +289,7 @@ define(['hgn!readium_js_viewer_html_templates/settings-keyboard-item.html', 'i18
     var saveKeys = function()
     {
         var atLeastOneChanged = false;
+        var atLeastOneInvalidOrDuplicate = false;
         var keys = {};
 
         checkKeyboardShortcuts();
@@ -306,6 +307,7 @@ define(['hgn!readium_js_viewer_html_templates/settings-keyboard-item.html', 'i18
             {
                 // if (original === val) return true; // continue (effectively resets to the default valid value)
                 val = original;
+                atLeastOneInvalidOrDuplicate = true;
             }
 
             if (!val.length) return true; // continue
@@ -319,12 +321,19 @@ define(['hgn!readium_js_viewer_html_templates/settings-keyboard-item.html', 'i18
                 keys[id] = val;
             }
         });
-        if (atLeastOneChanged)
+        if (atLeastOneChanged || atLeastOneInvalidOrDuplicate)
         {
             // TODO: anything more elegant than alert() ?
             //alert(Strings.i18n_keyboard_reload);
-
-            Dialogs.showModalMessage("Readium - " + Strings.i18n_keyboard_shortcuts, Strings.i18n_keyboard_reload);
+            var body = "";
+            if (atLeastOneChanged)
+            { 
+              body = "<p>" + Strings.i18n_keyboard_reload + "</p>";
+            }
+            if (atLeastOneInvalidOrDuplicate) {
+              body += "<p>" + Strings.i18n_keyboard_onerror_reset + "</p>";
+            }
+            Dialogs.showModalMessageEx("Readium - " + Strings.i18n_keyboard_shortcuts, body);
         }
 
         return keys;


### PR DESCRIPTION
*General Instructions*

Add new message for when the Keyboard Shortcut settings is saved but some of the settings are INVALID or DUPLICATE

#### This pull request is a Work In Progress 
until we agree upon the wording of the new message

#### Related issue(s) and/or pull request(s)
*Example: See also #533* This message dialog will not trap focus until 533 is fixed.

#### Test cases, sample files

Test by opening the keyboard shortcuts pane of the settings dialog.
Change the value of one of the settings to one that is already used by another shortcut.  DUPLICATE will appear in the field.  Press Save Changes - you should see a dialog with a message that the INVALID or DUPLICATE setting was restored to the original.

If a setting was legitimately changed and another was INALID or DUPLICATE when the settings were saved, two messages will be displayed in the dialog.  

Test combinations of just 
1) INVALID OR DUPLICATE settings - just one error message is displayed
2)correclty  changing a shortcut and also having one in error - two messages are displayed
3)correctly changing 1 or more shortcuts - just one reload message is displayed

### Additional information

I updated the message box to contain the appropriate messages
for saving and/or when one of the keyboard shortcuts was
tagged with INVALID or DUPLICATE when the shortcuts were saved.
Will require translation of a new message string currently only
add to en_US/messages.json