### PR TITLE
Fixes #552 set focus into details dialog

### DIFF
--- a/src/js/EpubLibrary.js
+++ b/src/js/EpubLibrary.js
@@ -182,6 +182,7 @@ Helpers){
         });
         $('#details-dialog').on('shown.bs.modal', function(){
             Keyboard.scope('details');
+            setTimeout(function(){ $('#closeEpubDetailsCross')[0].focus(); }, 1000);
         });
 
 


### PR DESCRIPTION

#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)
This is related to but does not rely on #553 so can be applied before or after #553 

Set focus onto the close icon in upper right
of the book details dialog when it is opened.

Test by opening the details dialog from the library view. Shortly after the dialog is visible, focus should be set to the close icon in the upper right corner. 