### PR TITLE
Fixes #551 selecting a file in Add to Library dialog automatically adds it

### DIFF
--- a/src/js/EpubLibrary.js
+++ b/src/js/EpubLibrary.js
@@ -387,37 +387,83 @@ Helpers){
         });
     };
 
-    var handleFileSelect = function(evt){
-        $('#add-epub-dialog').modal('hide');
-        
-        var file = evt.target.files[0];
-        importZippedEpub(file);
-    }
-
-    var handleDirSelect = function(evt){
-        var files = evt.target.files;
-        $('#add-epub-dialog').modal('hide');
-        Dialogs.showModalProgress(Strings.import_dlg_title, Strings.import_dlg_message);
-        libraryManager.handleDirectoryImport({
-            files: files,
-            overwrite: promptForReplace,
-            success: handleLibraryChange,
-            progress: Dialogs.updateProgress,
-            error: showError
-        });
+    var stageAddEpubInfo = function(type, data){
+      this.type = type;
+      this.epubData = data;
     }
     
-    var handleUrlSelect = function(){
-        var url = $('#url-upload').val();
-        $('#add-epub-dialog').modal('hide');
-        Dialogs.showModalProgress(Strings.import_dlg_title, Strings.import_dlg_message);
-        libraryManager.handleUrlImport({
-            url: url,
-            overwrite: promptForReplace,
-            success: handleLibraryChange,
-            progress: Dialogs.updateProgress,
-            error: showError
-        });
+    var addEpubInfo = null;
+    
+    var addEpubInputSelector = function() {
+      return '#add-epub-dialog input';
+    };
+    
+    var stageEpubAdd = function(evt) {
+      var type = evt.target.id;
+      var data = null;
+      var disableSelectors = "";
+      switch(type) {
+        case "epub-upload":
+          data=evt.target.files[0];
+          if (data) {
+            disableSelectors = "#dir-upload, #url-upload";
+          }
+        break;
+        case "dir-upload":
+          data = evt.target.files;
+          if (data && data.length > 0) {
+            disableSelectors = "#epub-upload, #url-upload";
+          }
+        break;
+        case "url-upload":
+          data = $('#url-upload').val();
+          if (data && data.length > 0) {
+            disableSelectors = "#epub-upload, #dir-upload";
+          }
+        break;
+        default:
+          $(".add-book").prop('disable', true);
+      }
+      if (disableSelectors.length > 0) {
+        addEpubInfo = new stageAddEpubInfo(type, data);
+        $(disableSelectors).prop('disabled', true);
+        $(".add-book").prop('disabled', false);
+      } else {
+        $(addEpubInputSelector()).prop('disabled',false);
+        $(".add-book").prop('disabled', true);
+      }
+    }
+    
+    var handleEpubAdd  = function(evt) {
+      $('#add-epub-dialog').modal('hide');
+      if (addEpubInfo) {
+        switch (addEpubInfo.type){
+          case "epub-upload":
+            importZippedEpub(addEpubInfo.epubData);
+          break;
+          case "dir-upload":
+          Dialogs.showModalProgress(Strings.import_dlg_title, Strings.import_dlg_message);
+          libraryManager.handleDirectoryImport({
+              files: addEpubInfo.epubData,
+              overwrite: promptForReplace,
+              success: handleLibraryChange,
+              progress: Dialogs.updateProgress,
+              error: showError
+          });
+          break;
+          case "url-upload":
+          Dialogs.showModalProgress(Strings.import_dlg_title, Strings.import_dlg_message);
+          libraryManager.handleUrlImport({
+              url: addEpubInfo.epubData,
+              overwrite: promptForReplace,
+              success: handleLibraryChange,
+              progress: Dialogs.updateProgress,
+              error: showError
+          });
+          break;
+        }
+      }
+      addEpubInfo = null;
     }
 
     var importEpub = function(ebook) {
@@ -490,6 +536,9 @@ Helpers){
 
         $('#add-epub-dialog').on('hidden.bs.modal', function () {
             Keyboard.scope('library');
+            //reset the input controls back to enabled
+            $(addEpubInputSelector()).prop('disabled', false);
+            $(".add-book").prop('disabled',true);
 
             setTimeout(function(){ $("#addbutt").focus(); }, 50);
         });
@@ -500,16 +549,21 @@ Helpers){
 
             setTimeout(function(){ $('#closeAddEpubCross')[0].focus(); }, 1000);
         });
-        $('#url-upload').on('keyup', function(){
-            var val = $(this).val();
-            if (val && val.length){
-                $('#add-epub-dialog .add-book').prop('disabled', false);
-            }
-            else{
-                $('#add-epub-dialog .add-book').prop('disabled', true);
-            }
-        });
-        $('.add-book').on('click', handleUrlSelect);
+
+        var timerid;	
+	    	$("#url-upload").on("input",function(e){
+          var value = $(this).val();
+          if($(this).data("lastval")!= value){
+            $(this).data("lastval",value);
+            
+            clearTimeout(timerid);
+            timerid = setTimeout(function() {
+              stageEpubAdd(e);
+            },1000);
+          };
+	    	});
+        
+        $('.add-book').on('click', handleEpubAdd);
         $('nav').empty();
         $('nav').attr("aria-label", Strings.i18n_toolbar);
         $('nav').append(LibraryNavbar({strings: Strings, dialogs: Dialogs, keyboard: Keyboard}));
@@ -541,8 +595,8 @@ Helpers){
 
         setAppSize();
         $(document.body).on('click', '.read', readClick);
-        $('#epub-upload').on('change', handleFileSelect);
-        $('#dir-upload').on('change', handleDirSelect);
+        $('#epub-upload').on('change', stageEpubAdd);
+        $('#dir-upload').on('change', stageEpubAdd);
 
         document.title = Strings.i18n_readium_library;
 


### PR DESCRIPTION
I think the current behavior in the Add to Library dialog is confusing. Currently when the user activates the file input and selects a file via the OS file manager/finder, that file is automatically processed for addition to the library.  This fix returns the user to the Add to Library dialog, enables the Add to Library button, and disables the other controls (since only one addition can be made at a time).  This fix does require an extra step from the user - she must now click/activate the Add to Library button to complete the addition but now has the opportunity to review and/or change the file before completing the add functionality.

#### This pull request is Finalized

#### Test cases, sample files
This was tedious to test because neither the cloud reader or chrome extension support all three file additions (by URL, by .epub, by unzipped dir).  For testing, I modified src/chrome-app/requirejs-config.js to display the add by URL input type=text control for testing  all 3 types in the Chrome app. This was necessary to make sure the enabling/disabling of the other inputs and the "Add to Library" button was properly implemented for all cases. 

This fix also supports canceling a selection since Chrome supports that feature.  The user can now
1) click on the file  inputs
2) make a selection from the finder
3) click "Choose" to return to the Add to Library dialog with the file name visible within the input
4) click on the input again, 
5) press cancel from the file manager/finder to return to the Add to Library dialog
6) there is no longer a file name in the input control (note that Safari and Firefox don't support this behavior).   


### Additional information
Original commit message: 

Modified the code so that after selecting a file in the
Add to Library dialog, the user is returned to the dialog
and must select the Add to Library button to process the addition.