### PR TITLE
Fixes #556 no alt text on about dialog logo image

### DIFF
--- a/src/i18n/_locales/en_US/messages.json
+++ b/src/i18n/_locales/en_US/messages.json
@@ -317,6 +317,9 @@
   "i18n_html_readium_tm_a_project" : {
     "message" : "Readium for Chrome is the Chrome browser extension configuration of ReadiumJS, an open source reading system and JavaScript library for displaying EPUB® publications in web browsers. ReadiumJS is a project of the Readium Foundation (Readium.org). To learn more or to contribute, visit the <a id=\"aboutFirst Focusable\" href=\"http://readium.org/projects/readiumjs\">project homepage</a>"
   },
+  "i18n_alt_about_logos" : {
+    "message" : "HTML5, i d p f, ePUB"
+  },
   "i18n_toolbar" : {
     "message" : "Toolbar"
   },

--- a/src/templates/about-dialog.html
+++ b/src/templates/about-dialog.html
@@ -10,7 +10,7 @@
               <span>{{{strings.i18n_html_readium_tm_a_project}}}</span>
           </div>
           <div>
-                 <img src="{{{imagePathPrefix}}}images/partner_logos.png">
+                 <img src="{{{imagePathPrefix}}}images/partner_logos.png" alt="{{{strings.i18n_alt_about_logos}}}">
             </div>
         <h4 style="color:#111155">{{{strings.gethelp}}}</h4>
         <div class="version">{{viewerJs.chromeVersion}}</div>


### PR DESCRIPTION
Added a message string that lists the logo contents into en_US/messages.json.
Updated the img element to add internationalized alt text.
#### This pull request is Other - may need discussion
### Additional information

NOTE: only the en_US version of this string is available but this probably doesn't need to be translated since logos and organization abbreviations are generally not translated.

Perhaps someone can suggest better alt text?  I didn't think that "partners" or "organizations" qualified since HTML5 is neither.  "Technologies" is an other possibility but there are many more used in the product and idpf isn't a technology. 

The other option is to provide empty alt text so that the image is ignored by screen readers but they seem to be on the dialog for a reason and are thus not considered just decorative. 
### Original commit message:

Added sting to en_US/messages.json that lists the 3
logo descriptions.  Added alt text string to the
about dialog template.
