### PR TITLE
Hypothesis support

### DIFF
--- a/src/js/EpubReader.js
+++ b/src/js/EpubReader.js
@@ -724,9 +724,33 @@ BookmarkData){
     }
 
     var savePlace = function(){
+
+        var urlParams = Helpers.getURLQueryParams();
+        var ebookURL = urlParams['epub'];
+        if (!ebookURL) return;
+
+        var bookmark = readium.reader.bookmarkCurrentPage();
+
         // Note: automatically JSON.stringify's the passed value!
         // ... and bookmarkCurrentPage() is already JSON.toString'ed, so that's twice!
-        Settings.put(ebookURL_filepath, readium.reader.bookmarkCurrentPage(), $.noop);
+        Settings.put(ebookURL_filepath, bookmark, $.noop);
+
+        bookmark = JSON.parse(bookmark);
+
+        bookmark.elementCfi = bookmark.contentCFI;
+        bookmark.contentCFI = undefined;
+        bookmark = JSON.stringify(bookmark);
+
+        ebookURL = ensureUrlIsRelativeToApp(ebookURL);
+
+        var url = Helpers.buildUrlQueryParameters(undefined, {
+            epub: ebookURL,
+            epubs: " ",
+            embedded: " ",
+            goto: bookmark
+        });
+
+        history.replaceState({}, "", url);
     }
 
     var nextPage = function () {

--- a/src/js/EpubReader.js
+++ b/src/js/EpubReader.js
@@ -1041,19 +1041,6 @@ BookmarkData){
         $('#zoom-custom a').on('click', enableCustom);
         $('.zoom-wrapper input').on('change', setCustom);
 
-        // UI tweaks for Hypothesis
-        window.hypothesisConfig = function () {
-            return {
-                onLayoutChange: function(state) {
-                    var $rightPageButton = $('#right-page-btn');
-                    $rightPageButton.css('right', state.width);
-                    if (!state.expanded) {
-                        $('nav').css('margin-right', state.width);
-                    }
-                }
-            };
-        };
-
         spin(true);
     }
 
@@ -1214,6 +1201,17 @@ BookmarkData){
                 if (readium.reader.plugins.example) {
                     readium.reader.plugins.example.on("exampleEvent", function(message) {
                         alert(message);
+                    });
+                }
+
+                if (readium.reader.plugins.hypothesis) {
+                    // Respond to requests for UI controls to make space for the Hypothesis sidebar
+                    readium.reader.plugins.hypothesis.on("offsetPageButton", function (offset) {
+                        var $rightPageButton = $('#right-page-btn');
+                        $rightPageButton.css('right', offset);
+                    });
+                    readium.reader.plugins.hypothesis.on("offsetNavBar", function (offset) {
+                        $('nav').css('margin-right', offset);
                     });
                 }
             });

--- a/src/js/EpubReader.js
+++ b/src/js/EpubReader.js
@@ -1041,6 +1041,19 @@ BookmarkData){
         $('#zoom-custom a').on('click', enableCustom);
         $('.zoom-wrapper input').on('change', setCustom);
 
+        // UI tweaks for Hypothesis
+        window.hypothesisConfig = function () {
+            return {
+                onLayoutChange: function(state) {
+                    var $rightPageButton = $('#right-page-btn');
+                    $rightPageButton.css('right', state.width);
+                    if (!state.expanded) {
+                        $('nav').css('margin-right', state.width);
+                    }
+                }
+            };
+        };
+
         spin(true);
     }
 

--- a/src/js/EpubReader.js
+++ b/src/js/EpubReader.js
@@ -735,23 +735,31 @@ BookmarkData){
         // ... and bookmarkCurrentPage() is already JSON.toString'ed, so that's twice!
         Settings.put(ebookURL_filepath, bookmark, $.noop);
 
-        bookmark = JSON.parse(bookmark);
+        if (!isChromeExtensionPackagedApp // History API is disabled in packaged apps
+              && window.history && window.history.replaceState) {
 
-        bookmark.elementCfi = bookmark.contentCFI;
-        bookmark.contentCFI = undefined;
-        bookmark = JSON.stringify(bookmark);
+            bookmark = JSON.parse(bookmark);
 
-        ebookURL = ensureUrlIsRelativeToApp(ebookURL);
+            bookmark.elementCfi = bookmark.contentCFI;
+            bookmark.contentCFI = undefined;
+            bookmark = JSON.stringify(bookmark);
 
-        var url = Helpers.buildUrlQueryParameters(undefined, {
-            epub: ebookURL,
-            epubs: " ",
-            embedded: " ",
-            goto: bookmark
-        });
+            ebookURL = ensureUrlIsRelativeToApp(ebookURL);
 
-        history.replaceState({}, "", url);
-    }
+            var url = Helpers.buildUrlQueryParameters(undefined, {
+                epub: ebookURL,
+                epubs: " ",
+                embedded: " ",
+                goto: bookmark
+            });
+
+            history.replaceState(
+                {epub: ebookURL, epubs: undefined},
+                "Readium Viewer",
+                url
+            );
+        }
+    };
 
     var nextPage = function () {
 


### PR DESCRIPTION
(Related) https://github.com/readium/readium-shared-js/pull/396

This pull request makes the reader's share URL always show up in the address bar and updates at every location change. This makes use of the browser's [History API](https://developer.mozilla.org/en-US/docs/Web/API/History)
This is needed for Hypothesis so that it could pick up on this URL and use it for sharing purposes as a direct link to a bookmarked location on the current page.

---

Hypothesis has some suggested UI tweaks to our UI that I have implemented as well:

- Providing a margin on the right for the sidebar when it's collapsed:
![image](https://user-images.githubusercontent.com/5132652/28696789-b608b8fe-72ec-11e7-860f-8d480e806d34.png)

- Shifting the right page turn button when the sidebar is open.
![image](https://user-images.githubusercontent.com/5132652/28697024-02d7c1ec-72ee-11e7-8e68-b2a35b99f31b.png)