### PR TITLE
Provide an initial state for the shared bookmark URL

### DIFF
--- a/src/js/EpubReader.js
+++ b/src/js/EpubReader.js
@@ -389,7 +389,15 @@ BookmarkData){
             Globals.logEvent("FXL_VIEW_RESIZED", "ON", "EpubReader.js");
             setScaleDisplay();
         });
-        
+
+
+        readium.reader.on(ReadiumSDK.Events.CONTENT_DOCUMENT_LOAD_START, function ($iframe, spineItem)
+        {
+            Globals.logEvent("CONTENT_DOCUMENT_LOAD_START", "ON", "EpubReader.js [ " + spineItem.href + " ]");
+            savePlace();
+        });
+
+
         readium.reader.on(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, function ($iframe, spineItem)
         {
             Globals.logEvent("CONTENT_DOCUMENT_LOADED", "ON", "EpubReader.js [ " + spineItem.href + " ]");
@@ -742,9 +750,9 @@ BookmarkData){
         if (!isChromeExtensionPackagedApp // History API is disabled in packaged apps
               && window.history && window.history.replaceState) {
 
-            bookmark = JSON.parse(bookmark);
+            bookmark = JSON.parse(bookmark) || {};
 
-            bookmark.elementCfi = bookmark.contentCFI;
+            bookmark.elementCfi = bookmark ? bookmark.contentCFI : null;
             bookmark.contentCFI = undefined;
             bookmark = JSON.stringify(bookmark);
 
@@ -1141,9 +1149,11 @@ BookmarkData){
                 var bookmark = JSON.parse(settings[ebookURL_filepath]);
                 // JSON.parse() a *second time* because the stored value is readium.reader.bookmarkCurrentPage(), which is JSON.toString'ed
                 bookmark = JSON.parse(bookmark);
-                //console.log("Bookmark restore: " + JSON.stringify(bookmark));
-                openPageRequest = {idref: bookmark.idref, elementCfi: bookmark.contentCFI};
-                console.debug("Open request (bookmark): " + JSON.stringify(openPageRequest));
+                if (bookmark && bookmark.idref) {
+                    //console.log("Bookmark restore: " + JSON.stringify(bookmark));
+                    openPageRequest = {idref: bookmark.idref, elementCfi: bookmark.contentCFI};
+                    console.debug("Open request (bookmark): " + JSON.stringify(openPageRequest));
+                }
             }
 
             var urlParams = Helpers.getURLQueryParams();


### PR DESCRIPTION
This change makes it so the URL to push to the history API is generated at the earliest point possible - when the spine item to load is first determined.
This fixes an edge case with the external_agent_support features of shared-js.

### How to test this:

- At this point we will test a part of the integration between Hypothesis and Readium in the cloud reader.
- To support linking back to annotations in the context of the reader app & source content Hypothesis can use a 'canonical' link element with an href. The value for this href in our case will be the reader's URL with two params, the epub location and the 'goto' bookmark location. 
- The URL to be used must contain the 'goto' param, or else it doesn't make sense to use it. If the URL was to be used without specifying the bookmark location then annotations associated with this canonical link would be for the whole book, which is bad. But if no canonical link exists then Hypothesis would fall back to associating with the content document's location, which is not ideal since that would mean the link to the annotation would just be the regular XHTML document without Readium.
- Open this link which will load a sample EPUB, notice the URL comes without a bookmark: https://readium.firebaseapp.com/?epub=epub_content%2Faccessible_epub_3&
- Since this URL doesn't initially start with a goto param, there won't be a canonical link element in the content iframe.
```js
window.top.ReadiumSDK.reader.getElement(window.top.ReadiumSDK.reader.getLoadedSpineItems()[0].idref, 'head link[rel=canonical]'); // undefined
``` 
- Hypothesis has no canonical link for this initial content frame.
- This PR fixes this by generating a goto param at the earliest point possible, when the spine items to load and the iframes are instantiated.
- But the iframe content isn't ready since it's still loading, therefore a bookmark CFI can't be created yet.
- A goto param with the idref and a null CFI would work at this state, the integration code with Hypothesis will have a canonical link element based on this goto param, and once the CFI is able to be generated on the full pagination, the canonical link is updated.
#### This pull request is Finalized
