### PR TITLE
Update fullscreen button icon and tooltip. Fixes #625

### DIFF
--- a/src/js/EpubReader.js
+++ b/src/js/EpubReader.js
@@ -637,8 +637,8 @@ BookmarkData){
             }
         };
     }
-    var oldOnChange = screenfull.onchange;
-    screenfull.onchange = function(e){
+
+    screenfull.onchange(function(e){
         var titleText;
 
         if (screenfull.isFullscreen)
@@ -657,8 +657,8 @@ BookmarkData){
             $('#buttFullScreenToggle').attr('aria-label', titleText);
             $('#buttFullScreenToggle').attr('title', titleText);
         }
-        oldOnChange.call(this, e);
-    }
+    });
+
     var unhideUI = function(){
         hideLoop();
     }


### PR DESCRIPTION
This fixes issue #625 by calling the sceenfull.onchange function instead of replacing it.