### PR TITLE
Exclude hypothesis highlights from theme styling

### DIFF
--- a/src/js/ReaderSettingsDialog.js
+++ b/src/js/ReaderSettingsDialog.js
@@ -17,7 +17,7 @@ define(['./ModuleConfig', 'hgn!readium_js_viewer_html_templates/settings-dialog.
         setPreviewTheme($previewText, theme);
         var previewStyle = window.getComputedStyle($previewText[0]);
         var bookStyles = [{
-            selector: 'body', // or "html", or "*", or "", or undefined (styles applied to whole document)
+            selector: ':not(a):not(hypothesis-highlight)', // or "html", or "*", or "", or undefined (styles applied to whole document)
             declarations: {
             backgroundColor: isAuthorTheme ? "" : previewStyle.backgroundColor,
             color: isAuthorTheme ? "" : previewStyle.color


### PR DESCRIPTION
Highlights created using _Hypothes.is_ don't render properly when using the viewer's content themes.

This change makes it so the theme's styles are still applied to the whole of the document, except it excludes two elements, <hypothesis-highlight> elements and <a> links.
