### PR TITLE
Change the 'goto' link param format to a full CFI expression

### DIFF
--- a/src/js/EpubReader.js
+++ b/src/js/EpubReader.js
@@ -771,11 +771,13 @@ BookmarkData){
             var bookmark = JSON.parse(bookmarkString) || {};
             var epubs = urlParams['epubs'];
 
+            var gotoParam = generateQueryParamCFI(bookmark);
+
             var url = Helpers.buildUrlQueryParameters(undefined, {
                 epub: ebookURL,
                 epubs: (epubs ? epubs : " "),
                 embedded: " ",
-                goto: {value: generateQueryParamCFI(bookmark), verbatim: true}
+                goto: {value: gotoParam ? gotoParam : " ", verbatim: true}
             });
 
             history.replaceState(


### PR DESCRIPTION
This makes a sharable bookmark link URL go from this:
`reader.html?epub=...&goto=%7B"idref"%3A"id-id2611884"%2C"elementCfi"%3A"%2F4%2F2%5Bintroduction%5D%2F18%2F12%2F1%3A329"%7D&`

To this:
`reader.html?epub=...&goto=epubcfi(/6/16!/4/2%5Bintroduction%5D/18/12/1:329)`

Yet still staying compatible with the previous format.

Before testing or merging this have your branches set to the `feature/full-cfi-bookmarking` in all submodules.
