### PR TITLE
Deprecation message in Chrome app

### DIFF
--- a/src/i18n/_locales/en_US/messages.json
+++ b/src/i18n/_locales/en_US/messages.json
@@ -450,6 +450,12 @@
   "i18n_page_navigation" : {
     "message" : "Page Navigation"
   },
+  "i18n_ChromeApp_deprecated_dialog_title" : {
+    "message" : "Readium Chrome App - WARNING"
+  },
+  "i18n_ChromeApp_deprecated_dialog_HTML" : {
+    "message" : "<p><strong><u>Important reminder</u></strong>:</p><p>Google decided to remove support for \"apps\" in the Chrome Web Browser, as <a href=\"https://developer.chrome.com/apps/migration\">explained here</a>.</p> <p>Google may decide to completely delete existing Chrome apps. This is outside of Readium's control.</p> <p>Consequently, please consider using alternative software to read EPUB files. Visit the <a href=\"https://readium.org\">Readium website</a> for suggestions.</p>"
+  },
   "chrome_accept_languages": {
     "message": "$CHROME$ accepts $languages$ languages",
     "placeholders": {

--- a/src/i18n/_locales/en_US/messages.json
+++ b/src/i18n/_locales/en_US/messages.json
@@ -448,9 +448,9 @@
     "message" : "Next Page"
   },
   "i18n_page_navigation" : {
-  "i18n_ChromeApp_deprecated_dialog_title" : {
     "message" : "Page Navigation"
   },
+  "i18n_ChromeApp_deprecated_dialog_title" : {
     "message" : "Readium Chrome App - WARNING"
   },
   "i18n_ChromeApp_deprecated_dialog_HTML" : {

--- a/src/i18n/_locales/en_US/messages.json
+++ b/src/i18n/_locales/en_US/messages.json
@@ -448,13 +448,13 @@
     "message" : "Next Page"
   },
   "i18n_page_navigation" : {
+  "i18n_ChromeApp_deprecated_dialog_title" : {
     "message" : "Page Navigation"
   },
-  "i18n_ChromeApp_deprecated_dialog_title" : {
     "message" : "Readium Chrome App - WARNING"
   },
   "i18n_ChromeApp_deprecated_dialog_HTML" : {
-    "message" : "<p><strong><u>Important reminder</u></strong>:</p><p>Google decided to remove support for \"apps\" in the Chrome Web Browser, as <a href=\"https://developer.chrome.com/apps/migration\">explained here</a>.</p> <p>Google may decide to completely delete existing Chrome apps. This is outside of Readium's control.</p> <p>Consequently, please consider using alternative software to read EPUB files. Visit the <a href=\"https://readium.org\">Readium website</a> for suggestions.</p>"
+    "message" : "<p><strong><u>IMPORTANT:</u></strong></p><p>This is the final release of the Readium Chrome App. Google decided to remove support for \"apps\" in the Chrome Web Browser, as <a href=\"https://developer.chrome.com/apps/migration\" target=\"_blank\">explained here</a>.</p> <p>At some point, Google will completely disable existing Chrome apps. This is unfortunately outside of Readium's control.</p> <p>Consequently, please consider using alternative software to read EPUB files. Visit the <a href=\"https://readium.org/about/applications.html/\" target=\"_blank\">Readium website</a> for suggestions.</p>"
   },
   "chrome_accept_languages": {
     "message": "$CHROME$ accepts $languages$ languages",

--- a/src/js/Dialogs.js
+++ b/src/js/Dialogs.js
@@ -94,6 +94,21 @@ define(['hgn!readium_js_viewer_html_templates/managed-dialog.html', 'hgn!readium
 
             showModalDialog(true, title, body, buttons);
         },
+        // Function below lifted off the "EPUB3 popup footnotes" feature branch:
+        // https://github.com/readium/readium-js-viewer/pull/505/files#diff-81e1ce6a00dd7f8664efb74b496611d9
+        showModalHTML : function(title, html){
+            var body = $(html),
+                buttons = ButtonTemplate({
+                    buttons : [
+                        {
+                            dismiss : true,
+                            text : Strings.ok
+                        }
+                    ]
+                });
+
+            showModalDialog(true, title, body, buttons);
+        },
         showModalMessageEx : function(title, body){
             var buttons = ButtonTemplate({
                     buttons : [

--- a/src/js/EpubLibrary.js
+++ b/src/js/EpubLibrary.js
@@ -651,6 +651,16 @@ Helpers){
             $("#buttClose").attr("accesskey", Keyboard.accesskeys.SettingsModalClose);
         });
 
+        var isChromeExtensionPackagedApp_ButNotChromeOS = (typeof chrome !== "undefined") && chrome.app
+            && chrome.app.window && chrome.app.window.current // a bit redundant?
+            && !/\bCrOS\b/.test(navigator.userAgent);
+
+        // TODO: remove the "true" condition in order to activate this feature *only* for the Chrome App (currently testing in cloud reader)
+        if (true || isChromeExtensionPackagedApp_ButNotChromeOS) {
+            setTimeout(function() {
+                Dialogs.showModalHTML(Strings.i18n_ChromeApp_deprecated_dialog_title, Strings.i18n_ChromeApp_deprecated_dialog_HTML);
+            }, 800);
+        }
 
         //async in Chrome
         Settings.get("needsMigration", function(needsMigration){

--- a/src/js/EpubLibrary.js
+++ b/src/js/EpubLibrary.js
@@ -655,8 +655,8 @@ Helpers){
             && chrome.app.window && chrome.app.window.current // a bit redundant?
             && !/\bCrOS\b/.test(navigator.userAgent);
 
-        // TODO: remove the "true" condition in order to activate this feature *only* for the Chrome App (currently testing in cloud reader)
-        if (true || isChromeExtensionPackagedApp_ButNotChromeOS) {
+        // test whether we are in the Chrome app.  If so, put up the dialog and whine at the users...
+        if (isChromeExtensionPackagedApp_ButNotChromeOS) {
             setTimeout(function() {
                 Dialogs.showModalHTML(Strings.i18n_ChromeApp_deprecated_dialog_title, Strings.i18n_ChromeApp_deprecated_dialog_HTML);
             }, 800);

--- a/src/js/EpubReader.js
+++ b/src/js/EpubReader.js
@@ -1106,17 +1106,6 @@ BookmarkData){
         {
             initReadium(); //async
         }, 0);
-
-        var isChromeExtensionPackagedApp_ButNotChromeOS = (typeof chrome !== "undefined") && chrome.app
-            && chrome.app.window && chrome.app.window.current // a bit redundant?
-            && !/\bCrOS\b/.test(navigator.userAgent);
-
-        // TODO: remove the "true" condition in order to activate this feature *only* for the Chrome App (currently testing in cloud reader)
-        if (true || isChromeExtensionPackagedApp_ButNotChromeOS) {
-            setTimeout(function() {
-                Dialogs.showModalHTML(Strings.i18n_ChromeApp_deprecated_dialog_title, Strings.i18n_ChromeApp_deprecated_dialog_HTML);
-            }, 800);
-        }
     };
 
     var initReadium = function(){

--- a/src/js/EpubReader.js
+++ b/src/js/EpubReader.js
@@ -1106,6 +1106,17 @@ BookmarkData){
         {
             initReadium(); //async
         }, 0);
+
+        var isChromeExtensionPackagedApp_ButNotChromeOS = (typeof chrome !== "undefined") && chrome.app
+            && chrome.app.window && chrome.app.window.current // a bit redundant?
+            && !/\bCrOS\b/.test(navigator.userAgent);
+
+        // TODO: remove the "true" condition in order to activate this feature *only* for the Chrome App (currently testing in cloud reader)
+        if (true || isChromeExtensionPackagedApp_ButNotChromeOS) {
+            setTimeout(function() {
+                Dialogs.showModalHTML(Strings.i18n_ChromeApp_deprecated_dialog_title, Strings.i18n_ChromeApp_deprecated_dialog_HTML);
+            }, 800);
+        }
     };
 
     var initReadium = function(){


### PR DESCRIPTION
Fixes https://github.com/readium/readium-js-viewer/issues/712

Note that the same nagging dialog pops up every time the library view is loaded. The user cannot tick a "stop nagging me" checkbox. The reading system does not limit the number of times the message is shown. There is no notion of reading "session" or time window during which the message should only be shown `x` number of times.

Test URL (library view):
http://readium-chromeapp.surge.sh/?epubs=https%3A%2F%2Freadium.firebaseapp.com%2Fepub_content%2Fepub_library.opds

Test URL (reader view, no nagging message):
http://readium-chromeapp.surge.sh/?epub=https%3A%2F%2Freadium.firebaseapp.com%2Fepub_content%2Faccessible_epub_3

Note that this Pull Request enables the nagging dialog for the cloud reader as well as the Chrome app, so that we can test this feature easily (using the above URLs). There is a boolean in the proposed code to enable this feature selectively, i.e. only for the Chrome app in the Chrome web browser, but not in Chrome OS.