### PR TITLE
fix bug: i18n translation load fail because of language names

### DIFF
--- a/src/i18n/Strings.js
+++ b/src/i18n/Strings.js
@@ -38,6 +38,10 @@ function(de, es, en_US, fr, it, id, ja, ko, pt_BR, zh_CN, zh_TW){
     Strings['zh_TW'] = zh_TW;
 
     var language = navigator.userLanguage || navigator.language;
+
+    // nagigator's language is 'zh-CN', but i18n is 'zh_CN'
+    language = language.replace("-", "_");
+
 //FORCE HERE (for testing)
 //language="es";
     console.log("Language: [" + language + "]");


### PR DESCRIPTION
Navigator's langauage is 'zh-CN', but i18n's language name is 'zh_CN', so it fails to load correct translation messsage.